### PR TITLE
Verified if 'resourceLoaderDependingInitHook' bean exists

### DIFF
--- a/extension/camunda-spring-boot-starter-webapp/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/CamundaBpmWebappAutoConfiguration.java
+++ b/extension/camunda-spring-boot-starter-webapp/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/CamundaBpmWebappAutoConfiguration.java
@@ -5,6 +5,7 @@ import org.camunda.bpm.spring.boot.starter.CamundaBpmProperties;
 import org.camunda.bpm.spring.boot.starter.webapp.filter.LazyDelegateFilter.InitHook;
 import org.camunda.bpm.spring.boot.starter.webapp.filter.ResourceLoaderDependingFilter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration.WebMvcAutoConfigurationAdapter;
@@ -23,6 +24,7 @@ public class CamundaBpmWebappAutoConfiguration extends WebMvcAutoConfigurationAd
   private ResourceLoader resourceLoader;
 
   @Autowired
+  @Qualifier("camundaBpmProperties")
   private CamundaBpmProperties properties;
 
   @Bean

--- a/extension/camunda-spring-boot-starter-webapp/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/filter/LazyFilterRuntimeListener.java
+++ b/extension/camunda-spring-boot-starter-webapp/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/filter/LazyFilterRuntimeListener.java
@@ -1,12 +1,16 @@
 package org.camunda.bpm.spring.boot.starter.webapp.filter;
 
 import org.camunda.bpm.spring.boot.starter.webapp.filter.LazyDelegateFilter.InitHook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringApplicationRunListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
 
 public class LazyFilterRuntimeListener implements SpringApplicationRunListener {
+  private final Logger logger = LoggerFactory.getLogger(getClass());
 
   public LazyFilterRuntimeListener(SpringApplication application, String[] args) {
     // convention
@@ -29,15 +33,18 @@ public class LazyFilterRuntimeListener implements SpringApplicationRunListener {
 
   @Override
   public void contextLoaded(ConfigurableApplicationContext context) {
-
   }
 
   @Override
   public void finished(ConfigurableApplicationContext context, Throwable exception) {
-    @SuppressWarnings("unchecked")
-    InitHook<ResourceLoaderDependingFilter> initHook = context.getBean("resourceLoaderDependingInitHook", InitHook.class);
-    init(LazySecurityFilter.INSTANCE, initHook);
-    init(LazyProcessEnginesFilter.INSTANCE, initHook);
+    if (context.containsBean("resourceLoaderDependingInitHook")) {
+      @SuppressWarnings("unchecked")
+      InitHook<ResourceLoaderDependingFilter> initHook = context.getBean("resourceLoaderDependingInitHook", InitHook.class);
+      init(LazySecurityFilter.INSTANCE, initHook);
+      init(LazyProcessEnginesFilter.INSTANCE, initHook);
+    } else {
+      logger.warn("Finished lazy runtime listener without access to resourceLoaderDependingInitHook");
+    }
   }
 
   private void init(LazyDelegateFilter<ResourceLoaderDependingFilter> filter, InitHook<ResourceLoaderDependingFilter> initHook) {

--- a/extension/camunda-spring-boot-starter-webapp/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/LazyFilterRuntimeListenerTest.java
+++ b/extension/camunda-spring-boot-starter-webapp/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/LazyFilterRuntimeListenerTest.java
@@ -2,6 +2,8 @@ package org.camunda.bpm.spring.boot.starter.webapp.filter;
 
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.camunda.bpm.spring.boot.starter.webapp.filter.LazyDelegateFilter.InitHook;
@@ -12,9 +14,12 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.context.ConfigurableApplicationContext;
 
+import static org.mockito.Matchers.anyList;
+
+import static org.camunda.bpm.engine.impl.metrics.parser.MetricsCmmnTransformListener.listener;
+
 @RunWith(MockitoJUnitRunner.class)
 public class LazyFilterRuntimeListenerTest {
-
   @Mock
   private ConfigurableApplicationContext context;
 
@@ -27,6 +32,7 @@ public class LazyFilterRuntimeListenerTest {
     LazyProcessEnginesFilter.INSTANCE = mock(LazyProcessEnginesFilter.class);
 
     LazyFilterRuntimeListener listener = new LazyFilterRuntimeListener(null, null);
+    when(context.containsBean("resourceLoaderDependingInitHook")).thenReturn(true);
     when(context.getBean("resourceLoaderDependingInitHook", InitHook.class)).thenReturn(initHookMock);
     listener.finished(context, null);
 
@@ -35,5 +41,21 @@ public class LazyFilterRuntimeListenerTest {
     order.verify(LazySecurityFilter.INSTANCE).lazyInit();
     order.verify(LazyProcessEnginesFilter.INSTANCE).setInitHook(initHookMock);
     order.verify(LazyProcessEnginesFilter.INSTANCE).lazyInit();
+  }
+
+  @Test
+  public void finishedWithoutInitHookTest() {
+    LazySecurityFilter.INSTANCE = mock(LazySecurityFilter.class);
+    LazyProcessEnginesFilter.INSTANCE = mock(LazyProcessEnginesFilter.class);
+
+    LazyFilterRuntimeListener listener = new LazyFilterRuntimeListener(null, null);
+    when(context.containsBean("resourceLoaderDependingInitHook")).thenReturn(false);
+    listener.finished(context, null);
+
+    verify(context, never()).getBean("resourceLoaderDependingInitHook");
+    verify(LazySecurityFilter.INSTANCE, never()).setInitHook(initHookMock);
+    verify(LazySecurityFilter.INSTANCE, never()).lazyInit();
+    verify(LazyProcessEnginesFilter.INSTANCE, never()).setInitHook(initHookMock);
+    verify(LazyProcessEnginesFilter.INSTANCE, never()).lazyInit();
   }
 }


### PR DESCRIPTION
In `LazyFilterRuntimeListener` the method `context.getBean()` was used. When using Spring cloud, the `SpringApplicationRunListener` gets executed twice, and at the first attempt the context is not yet created (bug?).

By checking if the context contains the bean first, no exceptions are thrown and the listener only initializes the filters when the context is initialized.

See #75 for more details.