### PR TITLE
issue #88, Application specific resource handler is added to prevent exposing al…

### DIFF
--- a/extension/camunda-spring-boot-starter-webapp/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/CamundaBpmWebappAutoConfiguration.java
+++ b/extension/camunda-spring-boot-starter-webapp/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/CamundaBpmWebappAutoConfiguration.java
@@ -1,17 +1,13 @@
 package org.camunda.bpm.spring.boot.starter.webapp;
 
 import org.camunda.bpm.spring.boot.starter.CamundaBpmAutoConfiguration;
-import org.camunda.bpm.spring.boot.starter.CamundaBpmProperties;
 import org.camunda.bpm.spring.boot.starter.webapp.filter.LazyDelegateFilter.InitHook;
 import org.camunda.bpm.spring.boot.starter.webapp.filter.ResourceLoaderDependingFilter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration.WebMvcAutoConfigurationAdapter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
@@ -22,6 +18,8 @@ import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 @ConditionalOnWebApplication
 @AutoConfigureAfter(CamundaBpmAutoConfiguration.class)
 public class CamundaBpmWebappAutoConfiguration extends WebMvcAutoConfigurationAdapter {
+  public static final String APP_RESOURCE_PATH = "/app/**";
+  private static final String[] APP_CLASSPATH_RESOURCE_LOCATIONS = {"classpath:/app/", "classpath:/static/", "classpath:/public/"};
 
   @Autowired
   private ResourceLoader resourceLoader;
@@ -47,7 +45,10 @@ public class CamundaBpmWebappAutoConfiguration extends WebMvcAutoConfigurationAd
 
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
-    registry.addResourceHandler("/**").addResourceLocations("classpath:/", "classpath:/static/");
+    registry.addResourceHandler("/**").addResourceLocations("classpath:/static/");
+    if (!registry.hasMappingForPattern(APP_RESOURCE_PATH)) {
+      registry.addResourceHandler(APP_RESOURCE_PATH).addResourceLocations(APP_CLASSPATH_RESOURCE_LOCATIONS);
+    }
     super.addResourceHandlers(registry);
   }
 


### PR DESCRIPTION
…l sensitive classpath files (ex: application.properties)

When spring boot app is launched, http://localhost:xxxx/application.properties reveals all information. Instead this should be blocked. 

Below change fixes the problem.