### PR TITLE
Fix too open resource mapping

### DIFF
--- a/extension/camunda-spring-boot-starter-webapp/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/CamundaBpmWebappAutoConfiguration.java
+++ b/extension/camunda-spring-boot-starter-webapp/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/CamundaBpmWebappAutoConfiguration.java
@@ -47,7 +47,12 @@ public class CamundaBpmWebappAutoConfiguration extends WebMvcAutoConfigurationAd
 
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
-    registry.addResourceHandler("/**").addResourceLocations("classpath:/", "classpath:/static/");
+    if (!registry.hasMappingForPattern("/**")) {
+      registry.addResourceHandler("/**").addResourceLocations("classpath:/static/","classpath:/public/");
+    }
+    registry.addResourceHandler("/lib/**").addResourceLocations("classpath:/lib/");
+    registry.addResourceHandler("/api/**").addResourceLocations("classpath:/api/");
+    registry.addResourceHandler("/app/**").addResourceLocations("classpath:/app/");
     super.addResourceHandlers(registry);
   }
 

--- a/extension/camunda-spring-boot-starter-webapp/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/CamundaBpmWebappAutoConfiguration.java
+++ b/extension/camunda-spring-boot-starter-webapp/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/CamundaBpmWebappAutoConfiguration.java
@@ -47,9 +47,6 @@ public class CamundaBpmWebappAutoConfiguration extends WebMvcAutoConfigurationAd
 
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
-    if (!registry.hasMappingForPattern("/**")) {
-      registry.addResourceHandler("/**").addResourceLocations("classpath:/static/","classpath:/public/");
-    }
     registry.addResourceHandler("/lib/**").addResourceLocations("classpath:/lib/");
     registry.addResourceHandler("/api/**").addResourceLocations("classpath:/api/");
     registry.addResourceHandler("/app/**").addResourceLocations("classpath:/app/");


### PR DESCRIPTION
Proper fix for security issue #88 . You have to explicit map all recource folders needed for camunda webapps. Now it workes fine for the camunda webapps and you can serve your own static resources from within /static/ and /public without exposes all resource files.