### PR TITLE
remove lombok

### DIFF
--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -61,11 +61,4 @@
     </dependencies>
   </dependencyManagement>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <scope>provided</scope>
-    </dependency>
-  </dependencies>
 </project>

--- a/extension/starter-rest/src/main/java/org/camunda/bpm/spring/boot/starter/rest/CamundaJerseyResourceConfig.java
+++ b/extension/starter-rest/src/main/java/org/camunda/bpm/spring/boot/starter/rest/CamundaJerseyResourceConfig.java
@@ -5,13 +5,13 @@ import javax.ws.rs.ApplicationPath;
 import org.camunda.bpm.engine.rest.impl.CamundaRestResources;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.InitializingBean;
 
-import lombok.extern.slf4j.Slf4j;
-
 @ApplicationPath("/rest")
-@Slf4j
 public class CamundaJerseyResourceConfig extends ResourceConfig implements InitializingBean {
+
+  private static final Logger log = org.slf4j.LoggerFactory.getLogger(CamundaJerseyResourceConfig.class);
 
   @Override
   public void afterPropertiesSet() throws Exception {

--- a/extension/starter-webapp-core/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/CamundaBpmWebappInitializer.java
+++ b/extension/starter-webapp-core/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/CamundaBpmWebappInitializer.java
@@ -28,18 +28,18 @@ import org.camunda.bpm.webapp.impl.engine.EngineRestApplication;
 import org.camunda.bpm.webapp.impl.security.auth.AuthenticationFilter;
 import org.camunda.bpm.welcome.impl.web.bootstrap.WelcomeContainerBootstrap;
 import org.glassfish.jersey.servlet.ServletContainer;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Inspired by:
  * https://groups.google.com/forum/#!msg/camunda-bpm-users/BQHdcLIivzs
  * /iNVix8GkhYAJ (Christoph Berg)
  */
-@Slf4j
 public class CamundaBpmWebappInitializer implements ServletContextInitializer {
+
+  private static final Logger log = org.slf4j.LoggerFactory.getLogger(CamundaBpmWebappInitializer.class);
 
   private static final EnumSet<DispatcherType> DISPATCHER_TYPES = EnumSet.of(DispatcherType.REQUEST);
 

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmNestedRuntimeException.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmNestedRuntimeException.java
@@ -1,0 +1,34 @@
+package org.camunda.bpm.spring.boot.starter;
+
+import org.springframework.core.NestedRuntimeException;
+
+/**
+ * Custom runtime exception that wraps a checked exception.
+ * <p>
+ * This class can be used when it is necessary to avoid the explicit throwing of checked exceptions.
+ * </p>
+ */
+public class CamundaBpmNestedRuntimeException extends NestedRuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Construct an exception with the specified detail message and nested exception.
+   * 
+   * @param msg the exception message
+   */
+  public CamundaBpmNestedRuntimeException(final String msg) {
+    super(msg);
+  }
+
+  /**
+   * Construct an exception with the specified detail message and nested exception.
+   * 
+   * @param msg the exception message
+   * @param cause the nested exception
+   */
+  public CamundaBpmNestedRuntimeException(final String msg, final Throwable cause) {
+    super(msg, cause);
+  }
+
+}

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/actuator/JobExecutorHealthIndicator.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/actuator/JobExecutorHealthIndicator.java
@@ -2,15 +2,14 @@ package org.camunda.bpm.spring.boot.starter.actuator;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import org.camunda.bpm.engine.impl.ProcessEngineImpl;
 import org.camunda.bpm.engine.impl.jobexecutor.JobExecutor;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health.Builder;
-
-import lombok.Singular;
-import lombok.Value;
 
 public class JobExecutorHealthIndicator extends AbstractHealthIndicator {
 
@@ -31,18 +30,28 @@ public class JobExecutorHealthIndicator extends AbstractHealthIndicator {
     builder.withDetail("jobExecutor", Details.from(jobExecutor));
   }
 
-  @Value
-  @lombok.Builder
   public static class Details {
 
-    private String name;
-    private String lockOwner;
-    private int lockTimeInMillis;
-    private int maxJobsPerAcquisition;
-    private int waitTimeInMillis;
+    private final String name;
+    private final String lockOwner;
+    private final int lockTimeInMillis;
+    private final int maxJobsPerAcquisition;
+    private final int waitTimeInMillis;
+    private final Set<String> processEngineNames;
+    
+    
+    private Details(DetailsBuilder builder) {
+      name = builder.name;
+      lockOwner = builder.lockOwner;
+      lockTimeInMillis = builder.lockTimeInMillis;
+      maxJobsPerAcquisition = builder.maxJobsPerAcquisition;
+      waitTimeInMillis = builder.waitTimeInMillis;
+      processEngineNames = java.util.Collections.unmodifiableSet(new HashSet<String>(builder.processEngineNames));
+    }
 
-    @Singular
-    private Set<String> processEngineNames;
+    public static DetailsBuilder builder() {
+      return new DetailsBuilder();
+    }
 
     private static Details from(JobExecutor jobExecutor) {
       final DetailsBuilder builder = Details.builder()
@@ -58,6 +67,104 @@ public class JobExecutorHealthIndicator extends AbstractHealthIndicator {
 
       return builder.build();
     }
+
+    public static class DetailsBuilder {
+
+      private String name;
+      private String lockOwner;
+      private int lockTimeInMillis;
+      private int maxJobsPerAcquisition;
+      private int waitTimeInMillis;
+      private Set<String> processEngineNames;
+
+      DetailsBuilder() {}
+
+      public DetailsBuilder name(String name) {
+        this.name = name;
+        return this;
+      }
+
+      public DetailsBuilder lockOwner(String lockOwner) {
+        this.lockOwner = lockOwner;
+        return this;
+      }
+
+      public DetailsBuilder lockTimeInMillis(int lockTimeInMillis) {
+        this.lockTimeInMillis = lockTimeInMillis;
+        return this;
+      }
+
+      public DetailsBuilder maxJobsPerAcquisition(int maxJobsPerAcquisition) {
+        this.maxJobsPerAcquisition = maxJobsPerAcquisition;
+        return this;
+      }
+
+      public DetailsBuilder waitTimeInMillis(int waitTimeInMillis) {
+        this.waitTimeInMillis = waitTimeInMillis;
+        return this;
+      }
+
+      public DetailsBuilder processEngineName(String processEngineName) {
+        if (this.processEngineNames == null) {
+          this.processEngineNames = new HashSet<String>();
+        }
+        this.processEngineNames.add(processEngineName);
+        return this;
+      }
+
+      public DetailsBuilder processEngineNames(Set<? extends String> processEngineNames) {
+        if (this.processEngineNames == null) {
+          this.processEngineNames = new HashSet<String>();
+        }
+        this.processEngineNames.addAll(processEngineNames);
+        return this;
+      }
+
+      public DetailsBuilder clearProcessEngineNames(Set<? extends String> processEngineNames) {
+        if (this.processEngineNames != null) {
+          this.processEngineNames.clear();
+        }
+        return this;
+      }
+
+      public Details build() {
+        return new Details(this);
+      }
+
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getLockOwner() {
+      return lockOwner;
+    }
+
+    public int getLockTimeInMillis() {
+      return lockTimeInMillis;
+    }
+
+    public int getMaxJobsPerAcquisition() {
+      return maxJobsPerAcquisition;
+    }
+
+    public int getWaitTimeInMillis() {
+      return waitTimeInMillis;
+    }
+
+    public Set<String> getProcessEngineNames() {
+      return processEngineNames;
+    }
+
+    @Override
+    public String toString() {
+      return "Details [name=" + name + ", lockOwner=" + lockOwner + ", lockTimeInMillis="
+          + lockTimeInMillis + ", maxJobsPerAcquisition=" + maxJobsPerAcquisition
+          + ", waitTimeInMillis=" + waitTimeInMillis + ", processEngineNames=" + processEngineNames
+          + "]";
+    }
+
   }
 
 }

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/jdbc/HistoryLevelDeterminatorJdbcTemplateImpl.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/jdbc/HistoryLevelDeterminatorJdbcTemplateImpl.java
@@ -8,18 +8,16 @@ import java.util.List;
 import org.camunda.bpm.engine.impl.history.HistoryLevel;
 import org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration;
 import org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
 public class HistoryLevelDeterminatorJdbcTemplateImpl implements HistoryLevelDeterminator, InitializingBean {
+  
+  private static final Logger log = org.slf4j.LoggerFactory.getLogger(HistoryLevelDeterminatorJdbcTemplateImpl.class);
 
   public static HistoryLevelDeterminator createHistoryLevelDeterminator(CamundaBpmProperties camundaBpmProperties, JdbcTemplate jdbcTemplate) {
     final HistoryLevelDeterminatorJdbcTemplateImpl determinator = new HistoryLevelDeterminatorJdbcTemplateImpl();
@@ -35,21 +33,45 @@ public class HistoryLevelDeterminatorJdbcTemplateImpl implements HistoryLevelDet
   protected final List<HistoryLevel> historyLevels = new ArrayList<HistoryLevel>(Arrays.asList(new HistoryLevel[] { HistoryLevel.HISTORY_LEVEL_ACTIVITY,
       HistoryLevel.HISTORY_LEVEL_AUDIT, HistoryLevel.HISTORY_LEVEL_FULL, HistoryLevel.HISTORY_LEVEL_NONE }));
 
-  @Getter
-  @Setter
   protected String defaultHistoryLevel = new SpringProcessEngineConfiguration().getHistory();
 
-  @Getter
-  @Setter
   protected JdbcTemplate jdbcTemplate;
 
-  @Getter
-  @Setter
   protected boolean ignoreDataAccessException = true;
 
-  @Getter
-  @Setter
   protected CamundaBpmProperties camundaBpmProperties;
+
+  public String getDefaultHistoryLevel() {
+    return defaultHistoryLevel;
+  }
+
+  public void setDefaultHistoryLevel(String defaultHistoryLevel) {
+    this.defaultHistoryLevel = defaultHistoryLevel;
+  }
+
+  public JdbcTemplate getJdbcTemplate() {
+    return jdbcTemplate;
+  }
+
+  public void setJdbcTemplate(JdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  public boolean isIgnoreDataAccessException() {
+    return ignoreDataAccessException;
+  }
+
+  public void setIgnoreDataAccessException(boolean ignoreDataAccessException) {
+    this.ignoreDataAccessException = ignoreDataAccessException;
+  }
+
+  public CamundaBpmProperties getCamundaBpmProperties() {
+    return camundaBpmProperties;
+  }
+
+  public void setCamundaBpmProperties(CamundaBpmProperties camundaBpmProperties) {
+    this.camundaBpmProperties = camundaBpmProperties;
+  }
 
   @Override
   public void afterPropertiesSet() throws Exception {

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/AdminUserProperty.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/AdminUserProperty.java
@@ -1,13 +1,12 @@
 package org.camunda.bpm.spring.boot.starter.property;
 
-import lombok.Data;
 import org.apache.commons.lang.StringUtils;
 import org.camunda.bpm.engine.identity.User;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang.WordUtils.capitalize;
 
-@Data
+
 public class AdminUserProperty implements User {
   private String id;
   private String firstName;
@@ -31,4 +30,61 @@ public class AdminUserProperty implements User {
 
     return this;
   }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  @Override
+  public String getFirstName() {
+    return firstName;
+  }
+
+  @Override
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  @Override
+  public String getLastName() {
+    return lastName;
+  }
+
+  @Override
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+
+  @Override
+  public String getEmail() {
+    return email;
+  }
+
+  @Override
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  @Override
+  public String toString() {
+    return "AdminUserProperty [id=" + id + ", firstName=" + firstName + ", lastName=" + lastName
+        + ", email=" + email + ", password=" + password + "]";
+  }
+
 }

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/ApplicationProperty.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/ApplicationProperty.java
@@ -1,6 +1,5 @@
 package org.camunda.bpm.spring.boot.starter.property;
 
-import lombok.Data;
 import org.camunda.bpm.application.impl.metadata.ProcessArchiveXmlImpl;
 import org.camunda.bpm.application.impl.metadata.spi.ProcessArchiveXml;
 import org.camunda.bpm.engine.repository.ResumePreviousBy;
@@ -10,8 +9,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-@Data
 public class ApplicationProperty {
+  
   /**
    * Indicates whether the undeployment of the process archive should trigger
    * deleting the process engine deployment. If the process engine deployment
@@ -44,6 +43,119 @@ public class ApplicationProperty {
    * deployment. Can be any of the options in {@link ResumePreviousBy}.
    */
   private String resumePreviousBy = ResumePreviousBy.RESUME_BY_PROCESS_DEFINITION_KEY;
+  
+  /**
+   * Gets the flag that indicates whether the undeployment of the process archive should trigger
+   * deleting the process engine deployment. If the process engine deployment is deleted, all
+   * running and historic process instances are removed as well.
+   * 
+   * @return {@code true} if the undeployment of the process archive should trigger deleting the
+   *         process engine deployment; otherwise {@code false}
+   */
+  public boolean isDeleteUponUndeploy() {
+    return isDeleteUponUndeploy;
+  }
+
+  /**
+   * Sets the flag that indicates whether the undeployment of the process archive should trigger
+   * deleting the process engine deployment. If the process engine deployment is deleted, all
+   * running and historic process instances are removed as well.
+   * 
+   * @param isDeleteUponUndeploy flag to indicate whether the undeployment of the process engine
+   *        should trigger deleting the process engine deployment ({@code true}) or not
+   *        ({@code false})
+   */
+  public void setDeleteUponUndeploy(boolean isDeleteUponUndeploy) {
+    this.isDeleteUponUndeploy = isDeleteUponUndeploy;
+  }
+ 
+  /**
+   * Gets the flag that indicates if the classloader should be scanned for process definitions.
+   * 
+   * @return {@code true} if the classloader should be scanned for process definitions; otherwise
+   *         {@code flase}
+   */
+  public boolean isScanForProcessDefinitions() {
+    return isScanForProcessDefinitions;
+  }
+
+  /**
+   * Sets the flag that indicates whether the classloader should be scanned for process definitions.
+   * 
+   * @param isScanForProcessDefinitions flag to indicate if the classloader should be scanned for
+   *        process definitions ({@code true}) or not ({@code false})
+   */
+  public void setScanForProcessDefinitions(boolean isScanForProcessDefinitions) {
+    this.isScanForProcessDefinitions = isScanForProcessDefinitions;
+  }
+
+  /**
+   * Gets the flag that indicates whether only changed resources should be part of the deployment.
+   * This is independent of the setting that if no resources change, no deployment takes place but
+   * the previous deployment is resumed.
+   * 
+   * @return {@code true} if only changed resources should be part of the deployment; otherwise
+   *         {@code false}
+   */
+  public boolean isDeployChangedOnly() {
+    return isDeployChangedOnly;
+  }
+
+  /**
+   * Sets the flag that indicates whether only changed resources should be part of the deployment.
+   * This is independent of the setting that if no resources change, no deployment takes place but
+   * the previous deployment is resumed.
+   * 
+   * @param isDeployChangedOnly the flag that indicates whether only changed resources should be
+   *        part of the deployment ({@code true}) or not {@code false})
+   */
+  public void setDeployChangedOnly(boolean isDeployChangedOnly) {
+    this.isDeployChangedOnly = isDeployChangedOnly;
+  }
+
+  /**
+   * Gets the flag that indicates whether old versions of the deployment should be resumed. If this
+   * property is not set, the default value is used: true.
+   * 
+   * @return the flag that indicates whether old versions of the deployment should be resumed ({@code
+   *         true}) or not ({@code false})
+   */
+  public boolean isResumePreviousVersions() {
+    return isResumePreviousVersions;
+  }
+
+  /**
+   * Sets the flag that indicates whether old versions of the deployment should be resumed. If this
+   * property is not set, the default value is used: true.
+   * 
+   * @param isResumePreviousVersions the flag that indicates whether old versions of the deployment
+   *        should be resumed ({@code true}) or not ({@code false})
+   */
+  public void setResumePreviousVersions(boolean isResumePreviousVersions) {
+    this.isResumePreviousVersions = isResumePreviousVersions;
+  }
+
+  /**
+   * Gets the value that indicates which previous deployments should be resumed by this deployment.
+   * Can be any of the options in {@link ResumePreviousBy}.
+   * 
+   * @return the value that indicates which previous deployments should be resumed by this
+   *         deployment
+   */
+  public String getResumePreviousBy() {
+    return resumePreviousBy;
+  }
+
+  /**
+   * Sets the value that indicates which previous deployments should be resumed by this deployment.
+   * Can be any of the options in {@link ResumePreviousBy}.
+   * 
+   * @param resumePreviousBy the value that indicates which previous deployments should be resumed
+   *        by this deployment
+   */
+  public void setResumePreviousBy(String resumePreviousBy) {
+    this.resumePreviousBy = resumePreviousBy;
+  }
 
   public List<ProcessArchiveXml> getProcessArchives() {
     List<ProcessArchiveXml> processArchives = new ArrayList<ProcessArchiveXml>();
@@ -63,6 +175,14 @@ public class ApplicationProperty {
     properties.put(ProcessArchiveXml.PROP_RESUME_PREVIOUS_BY, resumePreviousBy);
 
     return processArchives;
+  }
+
+  @Override
+  public String toString() {
+    return "ApplicationProperty [isDeleteUponUndeploy=" + isDeleteUponUndeploy
+        + ", isScanForProcessDefinitions=" + isScanForProcessDefinitions + ", isDeployChangedOnly="
+        + isDeployChangedOnly + ", isResumePreviousVersions=" + isResumePreviousVersions
+        + ", resumePreviousBy=" + resumePreviousBy + "]";
   }
 
 }

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/AuthorizationProperty.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/AuthorizationProperty.java
@@ -1,9 +1,7 @@
 package org.camunda.bpm.spring.boot.starter.property;
 
-import lombok.Data;
-import org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration;
+import java.util.Objects;
 
-@Data
 public class AuthorizationProperty {
 
   /**
@@ -17,4 +15,35 @@ public class AuthorizationProperty {
   private boolean enabledForCustomCode = Defaults.INSTANCE.isAuthorizationEnabledForCustomCode();
 
   private String authorizationCheckRevokes = Defaults.INSTANCE.getAuthorizationCheckRevokes();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public boolean isEnabledForCustomCode() {
+    return enabledForCustomCode;
+  }
+
+  public void setEnabledForCustomCode(boolean enabledForCustomCode) {
+    this.enabledForCustomCode = enabledForCustomCode;
+  }
+
+  public String getAuthorizationCheckRevokes() {
+    return authorizationCheckRevokes;
+  }
+
+  public void setAuthorizationCheckRevokes(String authorizationCheckRevokes) {
+    this.authorizationCheckRevokes = authorizationCheckRevokes;
+  }
+
+  @Override
+  public String toString() {
+    return "AuthorizationProperty [enabled=" + enabled + ", enabledForCustomCode="
+        + enabledForCustomCode + ", authorizationCheckRevokes=" + authorizationCheckRevokes + "]";
+  }
+
 }

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/CamundaBpmProperties.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/CamundaBpmProperties.java
@@ -1,6 +1,5 @@
 package org.camunda.bpm.spring.boot.starter.property;
 
-import lombok.Data;
 import org.camunda.bpm.engine.ProcessEngines;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -13,7 +12,6 @@ import java.util.Set;
 import static org.springframework.core.io.support.ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX;
 
 @ConfigurationProperties(CamundaBpmProperties.PREFIX)
-@Data
 public class CamundaBpmProperties {
 
   public static final String PREFIX = "camunda.bpm";
@@ -115,4 +113,154 @@ public class CamundaBpmProperties {
 
   @NestedConfigurationProperty
   private FilterProperty filter = new FilterProperty();
+
+  public String getProcessEngineName() {
+    return processEngineName;
+  }
+
+  public void setProcessEngineName(String processEngineName) {
+    this.processEngineName = processEngineName;
+  }
+
+  public String getHistoryLevel() {
+    return historyLevel;
+  }
+
+  public void setHistoryLevel(String historyLevel) {
+    this.historyLevel = historyLevel;
+  }
+
+  public String getHistoryLevelDefault() {
+    return historyLevelDefault;
+  }
+
+  public void setHistoryLevelDefault(String historyLevelDefault) {
+    this.historyLevelDefault = historyLevelDefault;
+  }
+
+  public boolean isAutoDeploymentEnabled() {
+    return autoDeploymentEnabled;
+  }
+
+  public void setAutoDeploymentEnabled(boolean autoDeploymentEnabled) {
+    this.autoDeploymentEnabled = autoDeploymentEnabled;
+  }
+
+  public String[] getDeploymentResourcePattern() {
+    return deploymentResourcePattern;
+  }
+
+  public void setDeploymentResourcePattern(String[] deploymentResourcePattern) {
+    this.deploymentResourcePattern = deploymentResourcePattern;
+  }
+
+  public String getDefaultSerializationFormat() {
+    return defaultSerializationFormat;
+  }
+
+  public void setDefaultSerializationFormat(String defaultSerializationFormat) {
+    this.defaultSerializationFormat = defaultSerializationFormat;
+  }
+
+  public URL getLicenseFile() {
+    return licenseFile;
+  }
+
+  public void setLicenseFile(URL licenseFile) {
+    this.licenseFile = licenseFile;
+  }
+
+  public MetricsProperty getMetrics() {
+    return metrics;
+  }
+
+  public void setMetrics(MetricsProperty metrics) {
+    this.metrics = metrics;
+  }
+
+  public DatabaseProperty getDatabase() {
+    return database;
+  }
+
+  public void setDatabase(DatabaseProperty database) {
+    this.database = database;
+  }
+
+  public JpaProperty getJpa() {
+    return jpa;
+  }
+
+  public void setJpa(JpaProperty jpa) {
+    this.jpa = jpa;
+  }
+
+  public JobExecutionProperty getJobExecution() {
+    return jobExecution;
+  }
+
+  public void setJobExecution(JobExecutionProperty jobExecution) {
+    this.jobExecution = jobExecution;
+  }
+
+  public WebappProperty getWebapp() {
+    return webapp;
+  }
+
+  public void setWebapp(WebappProperty webapp) {
+    this.webapp = webapp;
+  }
+
+  public ApplicationProperty getApplication() {
+    return application;
+  }
+
+  public void setApplication(ApplicationProperty application) {
+    this.application = application;
+  }
+
+  public AuthorizationProperty getAuthorization() {
+    return authorization;
+  }
+
+  public void setAuthorization(AuthorizationProperty authorization) {
+    this.authorization = authorization;
+  }
+
+  public GenericProperties getGenericProperties() {
+    return genericProperties;
+  }
+
+  public void setGenericProperties(GenericProperties genericProperties) {
+    this.genericProperties = genericProperties;
+  }
+
+  public AdminUserProperty getAdminUser() {
+    return adminUser;
+  }
+
+  public void setAdminUser(AdminUserProperty adminUser) {
+    this.adminUser = adminUser;
+  }
+
+  public FilterProperty getFilter() {
+    return filter;
+  }
+
+  public void setFilter(FilterProperty filter) {
+    this.filter = filter;
+  }
+
+  @Override
+  public String toString() {
+    return "CamundaBpmProperties [processEngineName=" + processEngineName + ", historyLevel="
+        + historyLevel + ", historyLevelDefault=" + historyLevelDefault + ", autoDeploymentEnabled="
+        + autoDeploymentEnabled + ", deploymentResourcePattern="
+        + Arrays.toString(deploymentResourcePattern) + ", defaultSerializationFormat="
+        + defaultSerializationFormat + ", licenseFile=" + licenseFile + ", metrics=" + metrics
+        + ", database=" + database + ", jpa=" + jpa + ", jobExecution=" + jobExecution + ", webapp="
+        + webapp + ", application=" + application + ", authorization=" + authorization
+        + ", genericProperties=" + genericProperties + ", adminUser=" + adminUser + ", filter="
+        + filter + "]";
+  }
+
 }

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/DatabaseProperty.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/DatabaseProperty.java
@@ -1,8 +1,5 @@
 package org.camunda.bpm.spring.boot.starter.property;
 
-import lombok.Data;
-import org.camunda.bpm.engine.ProcessEngineConfiguration;
-import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.springframework.util.Assert;
 
 import java.util.Arrays;
@@ -14,7 +11,6 @@ import static org.camunda.bpm.engine.ProcessEngineConfiguration.DB_SCHEMA_UPDATE
 import static org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl.DB_SCHEMA_UPDATE_CREATE;
 import static org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl.DB_SCHEMA_UPDATE_DROP_CREATE;
 
-@Data
 public class DatabaseProperty {
   public static final List<String> SCHEMA_UPDATE_VALUES = Arrays.asList(
     DB_SCHEMA_UPDATE_TRUE,
@@ -38,6 +34,10 @@ public class DatabaseProperty {
    */
   private String tablePrefix;
 
+  public String getSchemaUpdate() {
+    return schemaUpdate;
+  }
+
   /**
    * @param schemaUpdate the schemaUpdate to set
    */
@@ -45,4 +45,27 @@ public class DatabaseProperty {
     Assert.isTrue(SCHEMA_UPDATE_VALUES.contains(schemaUpdate), String.format("schemaUpdate: '%s' is not valid (%s)", schemaUpdate, SCHEMA_UPDATE_VALUES));
     this.schemaUpdate = schemaUpdate;
   }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public String getTablePrefix() {
+    return tablePrefix;
+  }
+
+  public void setTablePrefix(String tablePrefix) {
+    this.tablePrefix = tablePrefix;
+  }
+
+  @Override
+  public String toString() {
+    return "DatabaseProperty [schemaUpdate=" + schemaUpdate + ", type=" + type + ", tablePrefix="
+        + tablePrefix + "]";
+  }
+
 }

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/FilterProperty.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/FilterProperty.java
@@ -1,9 +1,20 @@
 package org.camunda.bpm.spring.boot.starter.property;
 
-import lombok.Data;
-
-@Data
 public class FilterProperty {
 
   private String create;
+
+  public String getCreate() {
+    return create;
+  }
+
+  public void setCreate(String create) {
+    this.create = create;
+  }
+
+  @Override
+  public String toString() {
+    return "FilterProperty [create=" + create + "]";
+  }
+
 }

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/GenericProperties.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/GenericProperties.java
@@ -1,15 +1,37 @@
 package org.camunda.bpm.spring.boot.starter.property;
 
-import lombok.Data;
-import lombok.Singular;
-
 import java.util.HashMap;
 import java.util.Map;
 
-@Data
 public class GenericProperties {
-  @Singular
+
   private Map<String, Object> properties = new HashMap<>();
   private boolean ignoreInvalidFields;
   private boolean ignoreUnknownFields;
+
+  public Map<String, Object> getProperties() {
+    return properties;
+  }
+  public void setProperties(Map<String, Object> properties) {
+    this.properties = properties;
+  }
+  public boolean isIgnoreInvalidFields() {
+    return ignoreInvalidFields;
+  }
+  public void setIgnoreInvalidFields(boolean ignoreInvalidFields) {
+    this.ignoreInvalidFields = ignoreInvalidFields;
+  }
+  public boolean isIgnoreUnknownFields() {
+    return ignoreUnknownFields;
+  }
+  public void setIgnoreUnknownFields(boolean ignoreUnknownFields) {
+    this.ignoreUnknownFields = ignoreUnknownFields;
+  }
+
+  @Override
+  public String toString() {
+    return "GenericProperties [properties=" + properties + ", ignoreInvalidFields="
+        + ignoreInvalidFields + ", ignoreUnknownFields=" + ignoreUnknownFields + "]";
+  }
+
 }

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/JobExecutionProperty.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/JobExecutionProperty.java
@@ -1,8 +1,5 @@
 package org.camunda.bpm.spring.boot.starter.property;
 
-import lombok.Data;
-
-@Data
 public class JobExecutionProperty {
 
   /**
@@ -23,5 +20,43 @@ public class JobExecutionProperty {
   private int corePoolSize = Defaults.TASK_EXECUTOR.getCorePoolSize();
   //private int maxPoolSize = Defaults.TASK_EXECUTOR.getMaxPoolSize();
   //private int keepAliveSeconds = Defaults.TASK_EXECUTOR.getKeepAliveSeconds();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public void setActive(boolean active) {
+    this.active = active;
+  }
+
+  public boolean isDeploymentAware() {
+    return deploymentAware;
+  }
+
+  public void setDeploymentAware(boolean deploymentAware) {
+    this.deploymentAware = deploymentAware;
+  }
+
+  public int getCorePoolSize() {
+    return corePoolSize;
+  }
+
+  public void setCorePoolSize(int corePoolSize) {
+    this.corePoolSize = corePoolSize;
+  }
+
+  @Override
+  public String toString() {
+    return "JobExecutionProperty [enabled=" + enabled + ", active=" + active + ", deploymentAware="
+        + deploymentAware + ", corePoolSize=" + corePoolSize + "]";
+  }
 
 }

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/JpaProperty.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/JpaProperty.java
@@ -1,8 +1,5 @@
 package org.camunda.bpm.spring.boot.starter.property;
 
-import lombok.Data;
-
-@Data
 public class JpaProperty {
   /**
    * enables JPA
@@ -23,4 +20,44 @@ public class JpaProperty {
    * handle transactions by JPA
    */
   private boolean handleTransaction = true;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getPersistenceUnitName() {
+    return persistenceUnitName;
+  }
+
+  public void setPersistenceUnitName(String persistenceUnitName) {
+    this.persistenceUnitName = persistenceUnitName;
+  }
+
+  public boolean isCloseEntityManager() {
+    return closeEntityManager;
+  }
+
+  public void setCloseEntityManager(boolean closeEntityManager) {
+    this.closeEntityManager = closeEntityManager;
+  }
+
+  public boolean isHandleTransaction() {
+    return handleTransaction;
+  }
+
+  public void setHandleTransaction(boolean handleTransaction) {
+    this.handleTransaction = handleTransaction;
+  }
+
+  @Override
+  public String toString() {
+    return "JpaProperty [enabled=" + enabled + ", persistenceUnitName=" + persistenceUnitName
+        + ", closeEntityManager=" + closeEntityManager + ", handleTransaction=" + handleTransaction
+        + "]";
+  }
+
 }

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/ManagementProperties.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/ManagementProperties.java
@@ -22,6 +22,11 @@ public class ManagementProperties {
     this.health = health;
   }
 
+  @Override
+  public String toString() {
+    return "ManagementProperties [health=" + health + "]";
+  }
+
   public static class Health {
 
     private Camunda camunda = new Camunda();
@@ -39,6 +44,11 @@ public class ManagementProperties {
      */
     public void setCamunda(Camunda camunda) {
       this.camunda = camunda;
+    }
+
+    @Override
+    public String toString() {
+      return "Health [camunda=" + camunda + "]";
     }
 
     public class Camunda {
@@ -59,6 +69,12 @@ public class ManagementProperties {
         this.enabled = enabled;
       }
 
+      @Override
+      public String toString() {
+        return "Camunda [enabled=" + enabled + "]";
+      }
+
     }
   }
+
 }

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/MetricsProperty.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/MetricsProperty.java
@@ -1,10 +1,27 @@
 package org.camunda.bpm.spring.boot.starter.property;
 
-import lombok.Data;
-
-@Data
 public class MetricsProperty {
 
   private boolean enabled = Defaults.INSTANCE.isMetricsEnabled();
   private boolean dbReporterActivate = Defaults.INSTANCE.isDbMetricsReporterActivate();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+  public boolean isDbReporterActivate() {
+    return dbReporterActivate;
+  }
+  public void setDbReporterActivate(boolean dbReporterActivate) {
+    this.dbReporterActivate = dbReporterActivate;
+  }
+
+  @Override
+  public String toString() {
+    return "MetricsProperty [enabled=" + enabled + ", dbReporterActivate=" + dbReporterActivate
+        + "]";
+  }
+
 }

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/WebappProperty.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/WebappProperty.java
@@ -1,8 +1,19 @@
 package org.camunda.bpm.spring.boot.starter.property;
 
-import lombok.Data;
-
-@Data
 public class WebappProperty {
   private boolean indexRedirectEnabled = true;
+
+  public boolean isIndexRedirectEnabled() {
+    return indexRedirectEnabled;
+  }
+
+  public void setIndexRedirectEnabled(boolean indexRedirectEnabled) {
+    this.indexRedirectEnabled = indexRedirectEnabled;
+  }
+
+  @Override
+  public String toString() {
+    return "WebappProperty [indexRedirectEnabled=" + indexRedirectEnabled + "]";
+  }
+
 }

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/util/GetProcessApplicationNameFromAnnotation.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/util/GetProcessApplicationNameFromAnnotation.java
@@ -1,12 +1,12 @@
 package org.camunda.bpm.spring.boot.starter.util;
 
-import lombok.Value;
 import org.apache.commons.lang.StringUtils;
 import org.camunda.bpm.spring.boot.starter.annotation.EnableProcessApplication;
 import org.springframework.context.ApplicationContext;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -24,14 +24,55 @@ public class GetProcessApplicationNameFromAnnotation implements Supplier<Optiona
     this.applicationContext = applicationContext;
   }
 
-  @Value(staticConstructor="of")
   public static class AnnotatedBean {
 
     String name;
     EnableProcessApplication annotation;
 
+    public AnnotatedBean(String name, EnableProcessApplication annotation) {
+      this.name = name;
+      this.annotation = annotation;
+    }
+
+    public static AnnotatedBean of(String name, EnableProcessApplication annotation) {
+      return new AnnotatedBean(name, annotation);
+    }
+
     public static AnnotatedBean of(String name, Object instance) {
       return of(name, instance.getClass().getAnnotation(EnableProcessApplication.class));
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public EnableProcessApplication getAnnotation() {
+      return annotation;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, annotation);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null) {
+        return false;
+      }
+      if (!(obj instanceof AnnotatedBean)) {
+        return false;
+      }
+      AnnotatedBean other = (AnnotatedBean) obj;
+      return Objects.equals(name, other.name) && Objects.equals(annotation, other.annotation);
+    }
+
+    @Override
+    public String toString() {
+      return "AnnotatedBean [name=" + name + ", annotation=" + annotation + "]";
     }
 
   }


### PR DESCRIPTION
resolves issue #152

The usage of lombok was removed the following way:

@Data
-> added Getter / Setter

@Value
-> added Getter 

@Builder / @Singular (only in JobExecutorHealthIndicator.Details class)
-> replaced by hand coded builder

@Singular without @Builder (only in GenericProperties class)
-> added Getter / Setter

@Slf4j
-> private static final org.slf4j.Logger log =
org.slf4j.LoggerFactory.getLogger(LogExample.class);

@SneakyThrows
-> Added CamundaBpmNestedRuntimeException and used this to wrap the
checked exceptions which should not be visible in the method signature.
This is worth to be reviewed as it may not be wanted to work with a
runtime exception here.

Also
* equals/hashCode methods were not regenerated by this refactoring
* toString was added on property classes (generated by IDE)
* polishing: removed unused imports when noticed