### PR TITLE
Removed unnecessary initialisation of camunda config arrays.

### DIFF
--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultFailedJobConfiguration.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultFailedJobConfiguration.java
@@ -1,17 +1,11 @@
 package org.camunda.bpm.spring.boot.starter.configuration.impl;
 
-import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParseListener;
 import org.camunda.bpm.engine.impl.bpmn.parser.FoxFailedJobParseListener;
-import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.jobexecutor.FoxFailedJobCommandFactory;
 import org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration;
 import org.camunda.bpm.spring.boot.starter.configuration.CamundaFailedJobConfiguration;
-import org.camunda.bpm.spring.boot.starter.util.CamundaSpringBootUtil;
 
 import java.util.ArrayList;
-import java.util.List;
-
-import static org.camunda.bpm.spring.boot.starter.util.CamundaSpringBootUtil.init;
 
 
 /**
@@ -21,7 +15,10 @@ public class DefaultFailedJobConfiguration extends AbstractCamundaConfiguration 
 
   @Override
   public void preInit(SpringProcessEngineConfiguration configuration) {
-    init(configuration);
+
+    if (configuration.getCustomPostBPMNParseListeners() == null) {
+      configuration.setCustomPostBPMNParseListeners(new ArrayList<>());
+    }
 
     configuration.getCustomPostBPMNParseListeners().add(new FoxFailedJobParseListener());
     configuration.setFailedJobCommandFactory(new FoxFailedJobCommandFactory());

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/util/CamundaSpringBootUtil.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/util/CamundaSpringBootUtil.java
@@ -8,7 +8,6 @@ import org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration;
 import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,38 +26,7 @@ public final class CamundaSpringBootUtil {
   }
 
   public static SpringProcessEngineConfiguration springProcessEngineConfiguration() {
-    final SpringProcessEngineConfiguration configuration = new SpringProcessEngineConfiguration();
-    return init(configuration);
-  }
-
-  /**
-   * Initializes empty collections.
-   *
-   * @param configuration the configuration to modify
-   * @return the configuration
-   */
-  public static SpringProcessEngineConfiguration init(SpringProcessEngineConfiguration configuration) {
-    if (configuration.getProcessEnginePlugins() == null) {
-      configuration.setProcessEnginePlugins(new ArrayList<>());
-    }
-
-    if (configuration.getBatchHandlers() == null) {
-      configuration.setBatchHandlers(new HashMap<>());
-    }
-
-    if (configuration.getBeans() == null) {
-      configuration.setBeans(new HashMap<>());
-    }
-
-    if (configuration.getCommandCheckers() == null) {
-      configuration.setCommandCheckers(new ArrayList<>());
-    }
-
-    if (configuration.getCustomPostBPMNParseListeners() == null) {
-      configuration.setCustomPostBPMNParseListeners(new ArrayList<>());
-    }
-
-    return configuration;
+    return new SpringProcessEngineConfiguration();
   }
 
   public static Optional<ProcessEngineImpl> processEngineImpl(ProcessEngine processEngine) {


### PR DESCRIPTION
 This causes skipping of default camunda initialization like batchHandlers (migration etc)  #196