### PR TITLE
Resolves the context path from the servlet context, fixes #213

### DIFF
--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/SpringBootProcessApplication.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/SpringBootProcessApplication.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.Resource;
 
+import javax.servlet.ServletContext;
 import java.util.Optional;
 import java.util.Set;
 
@@ -43,11 +44,14 @@ public class SpringBootProcessApplication extends SpringProcessApplication {
   @Value("${spring.application.name:null}")
   protected Optional<String> springApplicationName;
 
-  @Value("${server.contextPath:/}")
+  @Value("${server.contextPath:}")
   protected String contextPath;
 
   @Autowired
   protected ProcessEngine processEngine;
+
+  @Autowired
+  private ServletContext servletContext;
 
   @Override
   public void afterPropertiesSet() throws Exception {
@@ -57,7 +61,15 @@ public class SpringBootProcessApplication extends SpringProcessApplication {
 
     RuntimeContainerDelegate.INSTANCE.get().registerProcessEngine(processEngine);
 
-    properties.put(PROP_SERVLET_CONTEXT_PATH, contextPath);
+    if (contextPath.isEmpty()) {
+      if (servletContext.getContextPath().isEmpty()) {
+        this.properties.put(PROP_SERVLET_CONTEXT_PATH, "/");
+      } else {
+        this.properties.put(PROP_SERVLET_CONTEXT_PATH, servletContext.getContextPath());
+      }
+    } else {
+      this.properties.put(PROP_SERVLET_CONTEXT_PATH, this.contextPath);
+    }
     super.afterPropertiesSet();
   }
 


### PR DESCRIPTION
Resolves the context path from the servlet context (`javax.servlet.ServletContext`) if no context has been defined in the spring application properties file (`application.yaml`). This fixes #213.