### PR TITLE
feat(id-generator): use StrongUuidGenerator by default

### DIFF
--- a/extension/starter/pom.xml
+++ b/extension/starter/pom.xml
@@ -73,6 +73,10 @@
       <groupId>${project.groupId}</groupId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.uuid</groupId>
+      <artifactId>java-uuid-generator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.transaction</groupId>
       <artifactId>javax.transaction-api</artifactId>
       <scope>test</scope>

--- a/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultProcessEngineConfiguration.java
+++ b/extension/starter/src/main/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultProcessEngineConfiguration.java
@@ -1,5 +1,6 @@
 package org.camunda.bpm.spring.boot.starter.configuration.impl;
 
+import org.camunda.bpm.engine.impl.persistence.StrongUuidGenerator;
 import org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration;
 import org.camunda.bpm.spring.boot.starter.configuration.CamundaProcessEngineConfiguration;
 import org.springframework.util.StringUtils;
@@ -21,6 +22,8 @@ public class DefaultProcessEngineConfiguration extends AbstractCamundaConfigurat
     } else {
       logger.warn("Ignoring invalid defaultSerializationFormat='{}'", defaultSerializationFormat);
     }
+    
+    configuration.setIdGenerator(new StrongUuidGenerator());
   }
 
 }


### PR DESCRIPTION
The historic default DbIdGenerator is not safe to use in a cluster and should only be used in unit tests, but not in production. Since many users are using Spring Boot for microservices chances are very high that they have many applications using the same database and then run into deadlocks during db-based id generation.