### PR TITLE
Gradle EnterpriseWebjarPlugin does not longer add unnecessary libraries to compile classpath

### DIFF
--- a/gradle/webjar-gradle-plugin/src/main/groovy/org/camunda/bpm/spring/boot/gradle/CamundaWebjarPlugin.groovy
+++ b/gradle/webjar-gradle-plugin/src/main/groovy/org/camunda/bpm/spring/boot/gradle/CamundaWebjarPlugin.groovy
@@ -9,9 +9,7 @@ class CamundaWebjarPlugin implements Plugin<Project> {
     def myExt = project.extensions.create("camundaWebjarPlugin", CamundaWebjarPluginExtension)
 
     project.configurations {
-      camundaEE {
-        extendsFrom compile
-      }
+      extendsFrom compile
     }
 
     project.task("resolveCamundaEnterpriseWebjar") {


### PR DESCRIPTION
Configuration camundeEE, used to resolve the war file, does no longer extend compile and therefor does not add dependencies to compile scope.

Fixes #233