### PR TITLE
Fix IllegalStateException: ApplicationContext has been closed already when reloading application in IDE

### DIFF
--- a/extension/starter-webapp-core/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/filter/LazyInitRegistration.java
+++ b/extension/starter-webapp-core/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/filter/LazyInitRegistration.java
@@ -12,6 +12,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
 
 public class LazyInitRegistration implements ApplicationContextAware {
 
@@ -63,6 +65,11 @@ public class LazyInitRegistration implements ApplicationContextAware {
     for (LazyDelegateFilter<? extends Filter> lazyDelegateFilter : getRegistrations()) {
       lazyInit(lazyDelegateFilter);
     }
+  }
+  
+  @EventListener
+  protected void onContextClosed(ContextClosedEvent ev) {
+    APPLICATION_CONTEXT = null;
   }
 
   static Set<LazyDelegateFilter<? extends Filter>> getRegistrations() {


### PR DESCRIPTION
Listen for application context closed event and clear static APPLICATION_CONTEXT to prevent IllegalStateException: ApplicationContext has been closed already

When running Camunda Spring Boot Process Application from IDE one needs to use ability to hot reload application. Current implementation in 2.2.0 causes problem during reload, preventing reload and forcing to do stop/start of application.

It is caused by static APPLICATION_CONTEXT which is set and never clearing during closing of context when Spring Boot application is reloading.

This causes following exception in log:
```java
java.lang.IllegalStateException: org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext@1c83e4c4 has been closed already
	at org.springframework.context.support.AbstractApplicationContext.assertBeanFactoryActive(AbstractApplicationContext.java:1062) ~[spring-context-4.3.9.RELEASE.jar:4.3.9.RELEASE]
	at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1083) ~[spring-context-4.3.9.RELEASE.jar:4.3.9.RELEASE]
	at org.camunda.bpm.spring.boot.starter.webapp.filter.LazyInitRegistration.getInitHook(LazyInitRegistration.java:33) ~[camunda-bpm-spring-boot-starter-webapp-core-2.2.0.jar:2.2.0]
	at org.camunda.bpm.spring.boot.starter.webapp.filter.LazyInitRegistration.lazyInit(LazyInitRegistration.java:45) ~[camunda-bpm-spring-boot-starter-webapp-core-2.2.0.jar:2.2.0]
	at org.camunda.bpm.spring.boot.starter.webapp.filter.LazyDelegateFilter.init(LazyDelegateFilter.java:39) ~[camunda-bpm-spring-boot-starter-webapp-core-2.2.0.jar:2.2.0]
	at org.apache.catalina.core.ApplicationFilterConfig.initFilter(ApplicationFilterConfig.java:285) ~[tomcat-embed-core-8.5.15.jar:8.5.15]
	at org.apache.catalina.core.ApplicationFilterConfig.getFilter(ApplicationFilterConfig.java:266) ~[tomcat-embed-core-8.5.15.jar:8.5.15]
	at org.apache.catalina.core.ApplicationFilterConfig.<init>(ApplicationFilterConfig.java:108) ~[tomcat-embed-core-8.5.15.jar:8.5.15]
	at org.apache.catalina.core.StandardContext.filterStart(StandardContext.java:4590) [tomcat-embed-core-8.5.15.jar:8.5.15]
	at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5233) [tomcat-embed-core-8.5.15.jar:8.5.15]
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150) [tomcat-embed-core-8.5.15.jar:8.5.15]
	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1419) [tomcat-embed-core-8.5.15.jar:8.5.15]
	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1409) [tomcat-embed-core-8.5.15.jar:8.5.15]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_73]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_73]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_73]
	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_73]
```

Spring Boot reload fails with following exception:
```java
org.springframework.context.ApplicationContextException: Unable to start embedded container; nested exception is org.springframework.boot.context.embedded.EmbeddedServletContainerException: Unable to start embedded Tomcat
	at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.onRefresh(EmbeddedWebApplicationContext.java:137) ~[spring-boot-1.5.4.RELEASE.jar:1.5.4.RELEASE]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:537) ~[spring-context-4.3.9.RELEASE.jar:4.3.9.RELEASE]
	at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.refresh(EmbeddedWebApplicationContext.java:122) ~[spring-boot-1.5.4.RELEASE.jar:1.5.4.RELEASE]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:693) [spring-boot-1.5.4.RELEASE.jar:1.5.4.RELEASE]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:360) [spring-boot-1.5.4.RELEASE.jar:1.5.4.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:303) [spring-boot-1.5.4.RELEASE.jar:1.5.4.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1118) [spring-boot-1.5.4.RELEASE.jar:1.5.4.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1107) [spring-boot-1.5.4.RELEASE.jar:1.5.4.RELEASE]
	at ru.binbank.camunda.process.OpenAccountProcessApplication.main(OpenAccountProcessApplication.java:36) [classes/:na]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_73]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_73]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_73]
	at java.lang.reflect.Method.invoke(Method.java:497) ~[na:1.8.0_73]
	at org.springframework.boot.devtools.restart.RestartLauncher.run(RestartLauncher.java:49) [spring-boot-devtools-1.5.4.RELEASE.jar:1.5.4.RELEASE]
```

Version
===
Camunda Spring Boot Starter: 2.2.0
Camunda: 7.7.0
Spring Boot: 1.5.4
