### PR TITLE
Publish DelegateTask/DelegateTask/HistoryEvent as Spring Event

### DIFF
--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmAutoConfiguration.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmAutoConfiguration.java
@@ -4,15 +4,14 @@ import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.spring.ProcessEngineFactoryBean;
 import org.camunda.bpm.engine.spring.SpringProcessEngineServicesConfiguration;
-import org.camunda.bpm.model.bpmn.instance.camunda.CamundaProperties;
 import org.camunda.bpm.spring.boot.starter.event.EventPublisherPlugin;
 import org.camunda.bpm.spring.boot.starter.event.ProcessApplicationEventPublisher;
 import org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties;
+import org.camunda.bpm.spring.boot.starter.property.EventingProperty;
 import org.camunda.bpm.spring.boot.starter.property.ManagementProperties;
 import org.camunda.bpm.spring.boot.starter.util.CamundaBpmVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.cache.CacheProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -23,14 +22,14 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 
 @EnableConfigurationProperties({
-    CamundaBpmProperties.class,
-    ManagementProperties.class
+  CamundaBpmProperties.class,
+  ManagementProperties.class
 })
 @Import({
-    CamundaBpmConfiguration.class,
-    CamundaBpmActuatorConfiguration.class,
-    CamundaBpmPluginConfiguration.class,
-    SpringProcessEngineServicesConfiguration.class
+  CamundaBpmConfiguration.class,
+  CamundaBpmActuatorConfiguration.class,
+  CamundaBpmPluginConfiguration.class,
+  SpringProcessEngineServicesConfiguration.class
 })
 @ConditionalOnProperty(prefix = CamundaBpmProperties.PREFIX, name = "enabled", matchIfMissing = true)
 @AutoConfigureAfter(HibernateJpaAutoConfiguration.class)
@@ -46,7 +45,7 @@ public class CamundaBpmAutoConfiguration {
     @Bean
     public ProcessEngineFactoryBean processEngineFactoryBean() {
       final ProcessEngineFactoryBean factoryBean = new ProcessEngineFactoryBean();
-      factoryBean.setProcessEngineConfiguration(processEngineConfigurationImpl);
+      factoryBean.setProcessEngineConfiguration(processEngineConfigurationImpl); 
 
       return factoryBean;
     }
@@ -80,6 +79,6 @@ public class CamundaBpmAutoConfiguration {
 
   @Bean
   public EventPublisherPlugin eventPublisherPlugin(ApplicationEventPublisher publisher) {
-    return new EventPublisherPlugin(publisher);
+    return new EventPublisherPlugin(new EventingProperty(), publisher);
   }
 }

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmAutoConfiguration.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmAutoConfiguration.java
@@ -37,14 +37,14 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 
 @EnableConfigurationProperties({
-    CamundaBpmProperties.class,
-    ManagementProperties.class
+  CamundaBpmProperties.class,
+  ManagementProperties.class
 })
 @Import({
-    CamundaBpmConfiguration.class,
-    CamundaBpmActuatorConfiguration.class,
-    CamundaBpmPluginConfiguration.class,
-    SpringProcessEngineServicesConfiguration.class
+  CamundaBpmConfiguration.class,
+  CamundaBpmActuatorConfiguration.class,
+  CamundaBpmPluginConfiguration.class,
+  SpringProcessEngineServicesConfiguration.class
 })
 @Configuration
 @ConditionalOnProperty(prefix = CamundaBpmProperties.PREFIX, name = "enabled", matchIfMissing = true)
@@ -92,8 +92,4 @@ public class CamundaBpmAutoConfiguration {
     return new ProcessApplicationEventPublisher(publisher);
   }
 
-  @Bean
-  public EventPublisherPlugin eventPublisherPlugin(ApplicationEventPublisher publisher) {
-    return new EventPublisherPlugin(new EventingProperty(), publisher);
-  }
 }

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmAutoConfiguration.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmAutoConfiguration.java
@@ -5,6 +5,7 @@ import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.spring.ProcessEngineFactoryBean;
 import org.camunda.bpm.engine.spring.SpringProcessEngineServicesConfiguration;
 import org.camunda.bpm.model.bpmn.instance.camunda.CamundaProperties;
+import org.camunda.bpm.spring.boot.starter.event.EventPublisherPlugin;
 import org.camunda.bpm.spring.boot.starter.event.ProcessApplicationEventPublisher;
 import org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties;
 import org.camunda.bpm.spring.boot.starter.property.ManagementProperties;
@@ -35,6 +36,7 @@ import org.springframework.context.annotation.Primary;
 @AutoConfigureAfter(HibernateJpaAutoConfiguration.class)
 public class CamundaBpmAutoConfiguration {
 
+  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
   @Configuration
   class ProcessEngineConfigurationImplDependingConfiguration {
 
@@ -76,4 +78,8 @@ public class CamundaBpmAutoConfiguration {
     return new ProcessApplicationEventPublisher(publisher);
   }
 
+  @Bean
+  public EventPublisherPlugin eventPublisherPlugin(ApplicationEventPublisher publisher) {
+    return new EventPublisherPlugin(publisher);
+  }
 }

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmAutoConfiguration.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmAutoConfiguration.java
@@ -45,7 +45,7 @@ public class CamundaBpmAutoConfiguration {
     @Bean
     public ProcessEngineFactoryBean processEngineFactoryBean() {
       final ProcessEngineFactoryBean factoryBean = new ProcessEngineFactoryBean();
-      factoryBean.setProcessEngineConfiguration(processEngineConfigurationImpl); 
+      factoryBean.setProcessEngineConfiguration(processEngineConfigurationImpl);
 
       return factoryBean;
     }

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmAutoConfiguration.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2018 camunda services GmbH and various authors (info@camunda.com)
+ * Copyright © 2015-2019 camunda services GmbH and various authors (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmConfiguration.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmConfiguration.java
@@ -50,14 +50,18 @@ import org.camunda.bpm.spring.boot.starter.configuration.impl.DefaultMetricsConf
 import org.camunda.bpm.spring.boot.starter.configuration.impl.DefaultProcessEngineConfiguration;
 import org.camunda.bpm.spring.boot.starter.configuration.impl.custom.EnterLicenseKeyConfiguration;
 import org.camunda.bpm.spring.boot.starter.configuration.impl.GenericPropertiesConfiguration;
+import org.camunda.bpm.spring.boot.starter.event.EventPublisherPlugin;
+import org.camunda.bpm.spring.boot.starter.event.ProcessApplicationEventPublisher;
 import org.camunda.bpm.spring.boot.starter.jdbc.HistoryLevelDeterminator;
 import org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties;
+import org.camunda.bpm.spring.boot.starter.property.EventingProperty;
 import org.camunda.bpm.spring.boot.starter.util.CamundaBpmVersion;
 import org.camunda.bpm.spring.boot.starter.util.CamundaSpringBootUtil;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Import;
@@ -73,9 +77,7 @@ public class CamundaBpmConfiguration {
   @ConditionalOnMissingBean(ProcessEngineConfigurationImpl.class)
   public ProcessEngineConfigurationImpl processEngineConfigurationImpl(List<ProcessEnginePlugin> processEnginePlugins) {
     final SpringProcessEngineConfiguration configuration = CamundaSpringBootUtil.springProcessEngineConfiguration();
-
     configuration.getProcessEnginePlugins().add(new CompositeProcessEnginePlugin(processEnginePlugins));
-
     return configuration;
   }
 
@@ -184,4 +186,10 @@ public class CamundaBpmConfiguration {
   public CreateFilterConfiguration createFilterConfiguration() {
     return new CreateFilterConfiguration();
   }
+
+  @Bean
+  public EventPublisherPlugin eventPublisherPlugin(CamundaBpmProperties properties, ApplicationEventPublisher publisher) {
+    return new EventPublisherPlugin(properties.getEventing(), publisher);
+  }
+
 }

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/EventPublisherPlugin.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/EventPublisherPlugin.java
@@ -1,240 +1,68 @@
 package org.camunda.bpm.spring.boot.starter.event;
 
-import org.camunda.bpm.engine.delegate.ExecutionListener;
-import org.camunda.bpm.engine.delegate.TaskListener;
-import org.camunda.bpm.engine.impl.bpmn.behavior.UserTaskActivityBehavior;
-import org.camunda.bpm.engine.impl.bpmn.parser.AbstractBpmnParseListener;
-import org.camunda.bpm.engine.impl.cfg.AbstractProcessEnginePlugin;
-import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
-import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
-import org.camunda.bpm.engine.impl.pvm.process.ScopeImpl;
-import org.camunda.bpm.engine.impl.pvm.process.TransitionImpl;
-import org.camunda.bpm.engine.impl.task.TaskDefinition;
-import org.camunda.bpm.engine.impl.util.xml.Element;
+import org.camunda.bpm.engine.impl.history.handler.CompositeDbHistoryEventHandler;
 import org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration;
-import org.camunda.bpm.spring.boot.starter.configuration.CamundaProcessEngineConfiguration;
+import org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties;
+import org.camunda.bpm.spring.boot.starter.property.EventingProperty;
 import org.camunda.bpm.spring.boot.starter.util.SpringBootProcessEnginePlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static org.camunda.bpm.engine.delegate.ExecutionListener.EVENTNAME_END;
-import static org.camunda.bpm.engine.delegate.ExecutionListener.EVENTNAME_START;
-import static org.camunda.bpm.engine.delegate.ExecutionListener.EVENTNAME_TAKE;
-import static org.camunda.bpm.engine.delegate.TaskListener.EVENTNAME_ASSIGNMENT;
-import static org.camunda.bpm.engine.delegate.TaskListener.EVENTNAME_COMPLETE;
-import static org.camunda.bpm.engine.delegate.TaskListener.EVENTNAME_CREATE;
-import static org.camunda.bpm.engine.delegate.TaskListener.EVENTNAME_DELETE;
-
+/**
+ * Engine Plugin forwarding Camunda task, execution and history events as Spring Events.
+ */
 public class EventPublisherPlugin extends SpringBootProcessEnginePlugin {
 
-  public static final List<String> TASK_EVENTS = Arrays.asList(
-    EVENTNAME_COMPLETE,
-    EVENTNAME_ASSIGNMENT,
-    EVENTNAME_CREATE,
-    EVENTNAME_DELETE);
-  public static final List<String> EXECUTION_EVENTS = Arrays.asList(
-    EVENTNAME_START,
-    EVENTNAME_END);
+  private static final Logger logger = LoggerFactory.getLogger(EventPublisherPlugin.class);
 
-  private final TaskListener taskListener;
-  private final ExecutionListener executionListener;
+  private final EventingProperty property;
+  private final ApplicationEventPublisher publisher;
 
-  public EventPublisherPlugin(final ApplicationEventPublisher publisher) {
-    this.taskListener = publisher::publishEvent;
-    this.executionListener = publisher::publishEvent;
+  public EventPublisherPlugin(final CamundaBpmProperties properties, final ApplicationEventPublisher publisher) {
+    this(properties.getEventing(), publisher);
   }
+
+  public EventPublisherPlugin(final EventingProperty property, final ApplicationEventPublisher publisher) {
+    this.property = property;
+    this.publisher = publisher;
+  }
+
 
   @Override
   public void preInit(SpringProcessEngineConfiguration processEngineConfiguration) {
-    processEngineConfiguration.getCustomPostBPMNParseListeners().add(new PublishDelegateParseListener());
+
+    if (!property.isTask() && !property.isExecution() && !property.isHistory()) {
+      logger.info("EVENTING-002: Camunda Spring Boot Eventing Plugin is found, but disabled via property.");
+      return;
+    }
+
+    if (property.isTask() || property.isExecution()) {
+
+      logger.info("EVENTING-001: Initialized Camunda Spring Boot Eventing Engine Plugin.");
+      if (property.isTask()) {
+        logger.info("EVENTING-003: Task events are will be published as Spring Events.");
+      } else {
+        logger.info("EVENTING-004: Task eventing is disabled via property.");
+      }
+
+      if (property.isExecution()) {
+        logger.info("EVENTING-005: Execution events are will be published as Spring Events.");
+      } else {
+        logger.info("EVENTING-006: Execution eventing is disabled via property.");
+      }
+      // register parse listener
+      processEngineConfiguration.getCustomPostBPMNParseListeners().add(new PublishDelegateParseListener(this.publisher, property));
+    }
+
+    if (property.isHistory()) {
+      logger.info("EVENTING-007: History events will be published as Spring events.");
+      // register composite DB event handler.
+      processEngineConfiguration.setHistoryEventHandler(new CompositeDbHistoryEventHandler(new PublishHistoryEventHandler(this.publisher)));
+    } else {
+      logger.info("EVENTING-008: History eventing is disabled via property.");
+    }
+
   }
 
-  public class PublishDelegateParseListener extends AbstractBpmnParseListener {
-
-    @Override
-    public void parseUserTask(Element userTaskElement, ScopeImpl scope, ActivityImpl activity) {
-      addTaskListener(taskDefinition(activity));
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseBoundaryErrorEventDefinition(Element errorEventDefinition, boolean interrupting, ActivityImpl activity, ActivityImpl nestedErrorEventActivity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseBoundaryEvent(Element boundaryEventElement, ScopeImpl scopeElement, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseBoundaryMessageEventDefinition(Element element, boolean interrupting, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseBoundarySignalEventDefinition(Element signalEventDefinition, boolean interrupting, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseBoundaryTimerEventDefinition(Element timerEventDefinition, boolean interrupting, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseBusinessRuleTask(Element businessRuleTaskElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseCallActivity(Element callActivityElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseCompensateEventDefinition(Element compensateEventDefinition, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseEndEvent(Element endEventElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseEventBasedGateway(Element eventBasedGwElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseExclusiveGateway(Element exclusiveGwElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseInclusiveGateway(Element inclusiveGwElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseIntermediateCatchEvent(Element intermediateEventElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseIntermediateMessageCatchEventDefinition(Element messageEventDefinition, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseIntermediateSignalCatchEventDefinition(Element signalEventDefinition, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseIntermediateThrowEvent(Element intermediateEventElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseIntermediateTimerEventDefinition(Element timerEventDefinition, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseManualTask(Element manualTaskElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseMultiInstanceLoopCharacteristics(Element activityElement, Element multiInstanceLoopCharacteristicsElement, ActivityImpl activity) {
-      // DO NOT IMPLEMENT!
-      // we do not notify on entering a multi-instance activity, this will be done for every single execution inside that loop.
-    }
-
-    @Override
-    public void parseParallelGateway(Element parallelGwElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseProcess(Element processElement, ProcessDefinitionEntity processDefinition) {
-      // FIXME: is it a good idea to implement genenric global process listeners?
-    }
-
-    @Override
-    public void parseReceiveTask(Element receiveTaskElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseScriptTask(Element scriptTaskElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseSendTask(Element sendTaskElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseSequenceFlow(Element sequenceFlowElement, ScopeImpl scopeElement, TransitionImpl transition) {
-      addExecutionListener(transition);
-    }
-
-    @Override
-    public void parseServiceTask(Element serviceTaskElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseStartEvent(Element startEventElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseSubProcess(Element subProcessElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseTask(Element taskElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-    @Override
-    public void parseTransaction(Element transactionElement, ScopeImpl scope, ActivityImpl activity) {
-      addExecutionListener(activity);
-    }
-
-
-    void addExecutionListener(final ActivityImpl activity) {
-      for (String event : EXECUTION_EVENTS) {
-        activity.addListener(event, executionListener);
-      }
-    }
-
-    void addExecutionListener(final TransitionImpl transition) {
-      transition.addListener(EVENTNAME_TAKE, executionListener);
-    }
-
-    void addTaskListener(TaskDefinition taskDefinition) {
-      for (String event : TASK_EVENTS) {
-        taskDefinition.addTaskListener(event, taskListener);
-      }
-    }
-
-    /**
-     * @param activity the taskActivity
-     * @return taskDefinition for activity
-     */
-    TaskDefinition taskDefinition(final ActivityImpl activity) {
-      final UserTaskActivityBehavior activityBehavior = (UserTaskActivityBehavior) activity.getActivityBehavior();
-      return activityBehavior.getTaskDefinition();
-    }
-  }
 }

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/EventPublisherPlugin.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/EventPublisherPlugin.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2015-2019 camunda services GmbH and various authors (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.spring.boot.starter.event;
 
 import org.camunda.bpm.engine.impl.history.handler.CompositeDbHistoryEventHandler;

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/EventPublisherPlugin.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/EventPublisherPlugin.java
@@ -1,0 +1,240 @@
+package org.camunda.bpm.spring.boot.starter.event;
+
+import org.camunda.bpm.engine.delegate.ExecutionListener;
+import org.camunda.bpm.engine.delegate.TaskListener;
+import org.camunda.bpm.engine.impl.bpmn.behavior.UserTaskActivityBehavior;
+import org.camunda.bpm.engine.impl.bpmn.parser.AbstractBpmnParseListener;
+import org.camunda.bpm.engine.impl.cfg.AbstractProcessEnginePlugin;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
+import org.camunda.bpm.engine.impl.pvm.process.ScopeImpl;
+import org.camunda.bpm.engine.impl.pvm.process.TransitionImpl;
+import org.camunda.bpm.engine.impl.task.TaskDefinition;
+import org.camunda.bpm.engine.impl.util.xml.Element;
+import org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration;
+import org.camunda.bpm.spring.boot.starter.configuration.CamundaProcessEngineConfiguration;
+import org.camunda.bpm.spring.boot.starter.util.SpringBootProcessEnginePlugin;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.camunda.bpm.engine.delegate.ExecutionListener.EVENTNAME_END;
+import static org.camunda.bpm.engine.delegate.ExecutionListener.EVENTNAME_START;
+import static org.camunda.bpm.engine.delegate.ExecutionListener.EVENTNAME_TAKE;
+import static org.camunda.bpm.engine.delegate.TaskListener.EVENTNAME_ASSIGNMENT;
+import static org.camunda.bpm.engine.delegate.TaskListener.EVENTNAME_COMPLETE;
+import static org.camunda.bpm.engine.delegate.TaskListener.EVENTNAME_CREATE;
+import static org.camunda.bpm.engine.delegate.TaskListener.EVENTNAME_DELETE;
+
+public class EventPublisherPlugin extends SpringBootProcessEnginePlugin {
+
+  public static final List<String> TASK_EVENTS = Arrays.asList(
+    EVENTNAME_COMPLETE,
+    EVENTNAME_ASSIGNMENT,
+    EVENTNAME_CREATE,
+    EVENTNAME_DELETE);
+  public static final List<String> EXECUTION_EVENTS = Arrays.asList(
+    EVENTNAME_START,
+    EVENTNAME_END);
+
+  private final TaskListener taskListener;
+  private final ExecutionListener executionListener;
+
+  public EventPublisherPlugin(final ApplicationEventPublisher publisher) {
+    this.taskListener = publisher::publishEvent;
+    this.executionListener = publisher::publishEvent;
+  }
+
+  @Override
+  public void preInit(SpringProcessEngineConfiguration processEngineConfiguration) {
+    processEngineConfiguration.getCustomPostBPMNParseListeners().add(new PublishDelegateParseListener());
+  }
+
+  public class PublishDelegateParseListener extends AbstractBpmnParseListener {
+
+    @Override
+    public void parseUserTask(Element userTaskElement, ScopeImpl scope, ActivityImpl activity) {
+      addTaskListener(taskDefinition(activity));
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseBoundaryErrorEventDefinition(Element errorEventDefinition, boolean interrupting, ActivityImpl activity, ActivityImpl nestedErrorEventActivity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseBoundaryEvent(Element boundaryEventElement, ScopeImpl scopeElement, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseBoundaryMessageEventDefinition(Element element, boolean interrupting, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseBoundarySignalEventDefinition(Element signalEventDefinition, boolean interrupting, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseBoundaryTimerEventDefinition(Element timerEventDefinition, boolean interrupting, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseBusinessRuleTask(Element businessRuleTaskElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseCallActivity(Element callActivityElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseCompensateEventDefinition(Element compensateEventDefinition, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseEndEvent(Element endEventElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseEventBasedGateway(Element eventBasedGwElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseExclusiveGateway(Element exclusiveGwElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseInclusiveGateway(Element inclusiveGwElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseIntermediateCatchEvent(Element intermediateEventElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseIntermediateMessageCatchEventDefinition(Element messageEventDefinition, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseIntermediateSignalCatchEventDefinition(Element signalEventDefinition, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseIntermediateThrowEvent(Element intermediateEventElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseIntermediateTimerEventDefinition(Element timerEventDefinition, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseManualTask(Element manualTaskElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseMultiInstanceLoopCharacteristics(Element activityElement, Element multiInstanceLoopCharacteristicsElement, ActivityImpl activity) {
+      // DO NOT IMPLEMENT!
+      // we do not notify on entering a multi-instance activity, this will be done for every single execution inside that loop.
+    }
+
+    @Override
+    public void parseParallelGateway(Element parallelGwElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseProcess(Element processElement, ProcessDefinitionEntity processDefinition) {
+      // FIXME: is it a good idea to implement genenric global process listeners?
+    }
+
+    @Override
+    public void parseReceiveTask(Element receiveTaskElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseScriptTask(Element scriptTaskElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseSendTask(Element sendTaskElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseSequenceFlow(Element sequenceFlowElement, ScopeImpl scopeElement, TransitionImpl transition) {
+      addExecutionListener(transition);
+    }
+
+    @Override
+    public void parseServiceTask(Element serviceTaskElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseStartEvent(Element startEventElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseSubProcess(Element subProcessElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseTask(Element taskElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+    @Override
+    public void parseTransaction(Element transactionElement, ScopeImpl scope, ActivityImpl activity) {
+      addExecutionListener(activity);
+    }
+
+
+    void addExecutionListener(final ActivityImpl activity) {
+      for (String event : EXECUTION_EVENTS) {
+        activity.addListener(event, executionListener);
+      }
+    }
+
+    void addExecutionListener(final TransitionImpl transition) {
+      transition.addListener(EVENTNAME_TAKE, executionListener);
+    }
+
+    void addTaskListener(TaskDefinition taskDefinition) {
+      for (String event : TASK_EVENTS) {
+        taskDefinition.addTaskListener(event, taskListener);
+      }
+    }
+
+    /**
+     * @param activity the taskActivity
+     * @return taskDefinition for activity
+     */
+    TaskDefinition taskDefinition(final ActivityImpl activity) {
+      final UserTaskActivityBehavior activityBehavior = (UserTaskActivityBehavior) activity.getActivityBehavior();
+      return activityBehavior.getTaskDefinition();
+    }
+  }
+}

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/EventPublisherPlugin.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/EventPublisherPlugin.java
@@ -56,13 +56,13 @@ public class EventPublisherPlugin extends SpringBootProcessEnginePlugin {
 
       logger.info("EVENTING-001: Initialized Camunda Spring Boot Eventing Engine Plugin.");
       if (property.isTask()) {
-        logger.info("EVENTING-003: Task events are will be published as Spring Events.");
+        logger.info("EVENTING-003: Task events will be published as Spring Events.");
       } else {
         logger.info("EVENTING-004: Task eventing is disabled via property.");
       }
 
       if (property.isExecution()) {
-        logger.info("EVENTING-005: Execution events are will be published as Spring Events.");
+        logger.info("EVENTING-005: Execution events will be published as Spring Events.");
       } else {
         logger.info("EVENTING-006: Execution eventing is disabled via property.");
       }

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/PublishDelegateParseListener.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/PublishDelegateParseListener.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2015-2019 camunda services GmbH and various authors (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.spring.boot.starter.event;
 
 import org.camunda.bpm.engine.delegate.ExecutionListener;

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/PublishDelegateParseListener.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/PublishDelegateParseListener.java
@@ -1,0 +1,239 @@
+package org.camunda.bpm.spring.boot.starter.event;
+
+import org.camunda.bpm.engine.delegate.ExecutionListener;
+import org.camunda.bpm.engine.delegate.TaskListener;
+import org.camunda.bpm.engine.impl.bpmn.behavior.UserTaskActivityBehavior;
+import org.camunda.bpm.engine.impl.bpmn.parser.AbstractBpmnParseListener;
+import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
+import org.camunda.bpm.engine.impl.pvm.process.ScopeImpl;
+import org.camunda.bpm.engine.impl.pvm.process.TransitionImpl;
+import org.camunda.bpm.engine.impl.task.TaskDefinition;
+import org.camunda.bpm.engine.impl.util.xml.Element;
+import org.camunda.bpm.spring.boot.starter.property.EventingProperty;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.camunda.bpm.engine.delegate.ExecutionListener.*;
+import static org.camunda.bpm.engine.delegate.TaskListener.*;
+
+/**
+ * Parse listener adding provided execution and task listeners.
+ */
+public class PublishDelegateParseListener extends AbstractBpmnParseListener {
+
+  private static final List<String> TASK_EVENTS = Arrays.asList(
+    EVENTNAME_COMPLETE,
+    EVENTNAME_ASSIGNMENT,
+    EVENTNAME_CREATE,
+    EVENTNAME_DELETE);
+  private static final List<String> EXECUTION_EVENTS = Arrays.asList(
+    EVENTNAME_START,
+    EVENTNAME_END);
+
+  private final TaskListener taskListener;
+  private final ExecutionListener executionListener;
+
+  public PublishDelegateParseListener(final ApplicationEventPublisher publisher, final EventingProperty property) {
+
+    this.taskListener = delegateTask -> {
+      if (property.isTask()) {
+        publisher.publishEvent(delegateTask);
+      }
+    };
+
+    this.executionListener = delegateExecution -> {
+      if (property.isExecution()) {
+        publisher.publishEvent(delegateExecution);
+      }
+    };
+  }
+
+
+  @Override
+  public void parseUserTask(Element userTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    addTaskListener(taskDefinition(activity));
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseBoundaryErrorEventDefinition(Element errorEventDefinition, boolean interrupting, ActivityImpl activity, ActivityImpl nestedErrorEventActivity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseBoundaryEvent(Element boundaryEventElement, ScopeImpl scopeElement, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseBoundaryMessageEventDefinition(Element element, boolean interrupting, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseBoundarySignalEventDefinition(Element signalEventDefinition, boolean interrupting, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseBoundaryTimerEventDefinition(Element timerEventDefinition, boolean interrupting, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseBusinessRuleTask(Element businessRuleTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseCallActivity(Element callActivityElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseCompensateEventDefinition(Element compensateEventDefinition, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseEndEvent(Element endEventElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseEventBasedGateway(Element eventBasedGwElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseExclusiveGateway(Element exclusiveGwElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseInclusiveGateway(Element inclusiveGwElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseIntermediateCatchEvent(Element intermediateEventElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseIntermediateMessageCatchEventDefinition(Element messageEventDefinition, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseIntermediateSignalCatchEventDefinition(Element signalEventDefinition, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseIntermediateThrowEvent(Element intermediateEventElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseIntermediateTimerEventDefinition(Element timerEventDefinition, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseManualTask(Element manualTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseMultiInstanceLoopCharacteristics(Element activityElement, Element multiInstanceLoopCharacteristicsElement, ActivityImpl activity) {
+    // DO NOT IMPLEMENT
+    // we do not notify on entering a multi-instance activity, this will be done for every single execution inside that loop.
+  }
+
+  @Override
+  public void parseParallelGateway(Element parallelGwElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseProcess(Element processElement, ProcessDefinitionEntity processDefinition) {
+    // DO NOT IMPLEMENT
+  }
+
+  @Override
+  public void parseReceiveTask(Element receiveTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseScriptTask(Element scriptTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseSendTask(Element sendTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseSequenceFlow(Element sequenceFlowElement, ScopeImpl scopeElement, TransitionImpl transition) {
+    addExecutionListener(transition);
+  }
+
+  @Override
+  public void parseServiceTask(Element serviceTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseStartEvent(Element startEventElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseSubProcess(Element subProcessElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseTask(Element taskElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+  @Override
+  public void parseTransaction(Element transactionElement, ScopeImpl scope, ActivityImpl activity) {
+    addExecutionListener(activity);
+  }
+
+
+  private void addExecutionListener(final ActivityImpl activity) {
+    for (String event : EXECUTION_EVENTS) {
+      activity.addListener(event, executionListener);
+    }
+  }
+
+  private void addExecutionListener(final TransitionImpl transition) {
+    transition.addListener(EVENTNAME_TAKE, executionListener);
+  }
+
+  private void addTaskListener(TaskDefinition taskDefinition) {
+    for (String event : TASK_EVENTS) {
+      taskDefinition.addTaskListener(event, taskListener);
+    }
+  }
+
+  /**
+   * Retrieves task definition.
+   *
+   * @param activity the taskActivity
+   * @return taskDefinition for activity
+   */
+  private TaskDefinition taskDefinition(final ActivityImpl activity) {
+    final UserTaskActivityBehavior activityBehavior = (UserTaskActivityBehavior) activity.getActivityBehavior();
+    return activityBehavior.getTaskDefinition();
+  }
+}

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/PublishHistoryEventHandler.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/PublishHistoryEventHandler.java
@@ -1,0 +1,31 @@
+package org.camunda.bpm.spring.boot.starter.event;
+
+import org.camunda.bpm.engine.impl.history.event.HistoryEvent;
+import org.camunda.bpm.engine.impl.history.handler.HistoryEventHandler;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.List;
+
+/**
+ * Event handler publishing history events as Spring Events.
+ */
+public class PublishHistoryEventHandler implements HistoryEventHandler {
+
+  private final ApplicationEventPublisher publisher;
+
+  public PublishHistoryEventHandler(final ApplicationEventPublisher publisher) {
+    this.publisher = publisher;
+  }
+
+  @Override
+  public void handleEvent(HistoryEvent historyEvent) {
+    this.publisher.publishEvent(historyEvent);
+  }
+
+  @Override
+  public void handleEvents(final List<HistoryEvent> eventList) {
+    if (eventList != null) {
+      eventList.forEach(this::handleEvent);
+    }
+  }
+}

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/PublishHistoryEventHandler.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/PublishHistoryEventHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2015-2019 camunda services GmbH and various authors (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.spring.boot.starter.event;
 
 import org.camunda.bpm.engine.impl.history.event.HistoryEvent;

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/CamundaBpmProperties.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/CamundaBpmProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2018 camunda services GmbH and various authors (info@camunda.com)
+ * Copyright © 2015-2019 camunda services GmbH and various authors (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/CamundaBpmProperties.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/CamundaBpmProperties.java
@@ -76,7 +76,7 @@ public class CamundaBpmProperties {
   private URL licenseFile;
 
   /**
-   * decativate camunda auto configuration
+   * deactivate camunda auto configuration
    */
   private boolean enabled = true;
 
@@ -91,6 +91,12 @@ public class CamundaBpmProperties {
    */
   @NestedConfigurationProperty
   private DatabaseProperty database = new DatabaseProperty();
+
+  /**
+   * Spring eventing configuration
+   */
+  @NestedConfigurationProperty
+  private EventingProperty eventing = new EventingProperty();
 
   /**
    * JPA configuration
@@ -199,6 +205,10 @@ public class CamundaBpmProperties {
   public void setDatabase(DatabaseProperty database) {
     this.database = database;
   }
+
+  public EventingProperty getEventing() { return eventing; }
+
+  public void setEventing(EventingProperty eventing) { this.eventing = eventing; }
 
   public JpaProperty getJpa() {
     return jpa;

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/EventingProperty.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/EventingProperty.java
@@ -1,0 +1,55 @@
+package org.camunda.bpm.spring.boot.starter.property;
+
+import static org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties.joinOn;
+
+/**
+ * Properties controlling spring eventing.
+ */
+public class EventingProperty {
+
+  /**
+   * Controls events of execution listener.
+   */
+  private boolean execution = true;
+  /**
+   * Controls events of task listener.
+   */
+  private boolean task = true;
+  /**
+   * Controls events of history handler.
+   */
+  private boolean history = true;
+
+  public boolean isExecution() {
+    return execution;
+  }
+
+  public void setExecution(boolean execution) {
+    this.execution = execution;
+  }
+
+  public boolean isTask() {
+    return task;
+  }
+
+  public void setTask(boolean task) {
+    this.task = task;
+  }
+
+  public boolean isHistory() {
+    return history;
+  }
+
+  public void setHistory(boolean history) {
+    this.history = history;
+  }
+
+  @Override
+  public String toString() {
+    return joinOn(this.getClass())
+      .add("execution=" + execution)
+      .add("task=" + task)
+      .add("history=" + history)
+      .toString();
+  }
+}

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/EventingProperty.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/EventingProperty.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2015-2019 camunda services GmbH and various authors (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.spring.boot.starter.property;
 
 import static org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties.joinOn;

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/EventingProperty.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/EventingProperty.java
@@ -15,6 +15,8 @@
  */
 package org.camunda.bpm.spring.boot.starter.property;
 
+import org.apache.commons.lang3.BooleanUtils;
+
 import static org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties.joinOn;
 
 /**
@@ -25,37 +27,41 @@ public class EventingProperty {
   /**
    * Controls events of execution listener.
    */
-  private boolean execution = true;
+  private Boolean execution = Boolean.TRUE;
   /**
    * Controls events of task listener.
    */
-  private boolean task = true;
+  private Boolean task = Boolean.TRUE;
   /**
    * Controls events of history handler.
    */
-  private boolean history = true;
+  private Boolean history = Boolean.TRUE;
 
-  public boolean isExecution() {
-    return execution;
+  public EventingProperty() {
+
   }
 
-  public void setExecution(boolean execution) {
+  public boolean isExecution() {
+    return BooleanUtils.isTrue(execution);
+  }
+
+  public void setExecution(Boolean execution) {
     this.execution = execution;
   }
 
-  public boolean isTask() {
-    return task;
+  public Boolean isTask() {
+    return BooleanUtils.isTrue(task);
   }
 
-  public void setTask(boolean task) {
+  public void setTask(Boolean task) {
     this.task = task;
   }
 
-  public boolean isHistory() {
-    return history;
+  public Boolean isHistory() {
+    return BooleanUtils.isTrue(history);
   }
 
-  public void setHistory(boolean history) {
+  public void setHistory(Boolean history) {
     this.history = history;
   }
 

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CamundaEventingDisabledIT.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CamundaEventingDisabledIT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015-2019 camunda services GmbH and various authors (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter;
+
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.spring.boot.starter.test.nonpa.TestApplication;
+import org.camunda.bpm.spring.boot.starter.test.nonpa.TestEventCaptor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.transaction.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+  classes = {TestApplication.class},
+  webEnvironment = WebEnvironment.NONE
+)
+@ActiveProfiles("noeventing")
+@Transactional
+public class CamundaEventingDisabledIT extends AbstractCamundaAutoConfigurationIT {
+
+  @Autowired
+  private RuntimeService runtime;
+
+  @Autowired
+  private TaskService taskService;
+
+  @Autowired
+  private TestEventCaptor eventCaptor;
+
+  private ProcessInstance instance;
+
+  @Before
+  public void init() {
+    ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery()
+      .processDefinitionKey("eventing")
+      .singleResult();
+    assertThat(processDefinition).isNotNull();
+
+    eventCaptor.historyEvents.clear();
+    instance = runtime.startProcessInstanceByKey("eventing");
+  }
+
+  @After
+  public void stop() {
+    if (instance != null) {
+      // update stale instance
+      instance = runtime.createProcessInstanceQuery().processInstanceId(instance.getProcessInstanceId()).active().singleResult();
+      if (instance != null) {
+        runtime.deleteProcessInstance(instance.getProcessInstanceId(), "eventing shutdown");
+      }
+    }
+  }
+
+  @Test
+  public final void shouldEventTaskCreation() {
+
+    Task task = taskService.createTaskQuery().active().singleResult();
+    taskService.complete(task.getId());
+
+    assertThat(eventCaptor.taskEvents).isEmpty();
+    assertThat(eventCaptor.executionEvents).isEmpty();
+    assertThat(eventCaptor.historyEvents).isEmpty();
+
+  }
+
+}

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CamundaEventingIT.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CamundaEventingIT.java
@@ -45,7 +45,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(
   classes = {TestApplication.class},
   webEnvironment = WebEnvironment.NONE,
-  properties = {"camunda.bpm.history-level=full"}
+  properties = {
+    "camunda.bpm.history-level=full",
+    "camunda.bpm.eventing.execution=true",
+    "camunda.bpm.eventing.history=true",
+    "camunda.bpm.eventing.task=true"
+  }
 )
 @Transactional
 public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
@@ -84,7 +89,8 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
   }
 
   @Test
-  public final void should_event_task_creation() {
+  public final void shouldEventTaskCreation() {
+
     assertThat(eventCaptor.taskEvents).isNotEmpty();
 
     Task task = taskService.createTaskQuery().active().singleResult();
@@ -96,7 +102,7 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
   }
 
   @Test
-  public final void should_event_task_assignment() {
+  public final void shouldEventTaskAssignment() {
 
     // given
     assertThat(eventCaptor.taskEvents).isNotEmpty();
@@ -115,7 +121,7 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
 
 
   @Test
-  public final void should_event_task_complete() {
+  public final void shouldEventTaskComplete() {
 
     // given
     assertThat(eventCaptor.taskEvents).isNotEmpty();
@@ -133,7 +139,7 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
   }
 
   @Test
-  public final void should_event_task_delete() {
+  public final void shouldEventTaskDelete() {
 
     // given
     assertThat(eventCaptor.taskEvents).isNotEmpty();
@@ -151,7 +157,7 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
   }
 
   @Test
-  public final void should_event_execution() {
+  public final void shouldEventExecution() {
 
     // given
     assertThat(eventCaptor.executionEvents).isNotEmpty();
@@ -169,7 +175,7 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
   }
 
   @Test
-  public final void should_event_history_task_assignment_changes() {
+  public final void shouldEventHistoryTaskAssignmentChanges() {
     // given
     assertThat(eventCaptor.historyEvents).isNotEmpty();
     eventCaptor.historyEvents.clear();
@@ -235,7 +241,7 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
 
 
   @Test
-  public void should_event_history_task_attribute_changes() {
+  public void shouldEventHistoryTaskAttributeChanges() {
     assertThat(eventCaptor.historyEvents).isNotEmpty();
     eventCaptor.historyEvents.clear();
 
@@ -256,7 +262,7 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
   }
 
   @Test
-  public void should_event_history_task_multiple_assignment_changes() {
+  public void shouldEventHistoryTaskMultipleAssignmentChanges() {
 
     // given
     assertThat(eventCaptor.historyEvents).isNotEmpty();
@@ -297,7 +303,7 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
   }
 
   @Test
-  public void should_event_history_task_follow_up_date_changes() {
+  public void shouldEventHistoryTaskFollowUpDateChanges() {
     assertThat(eventCaptor.historyEvents).isNotEmpty();
     eventCaptor.historyEvents.clear();
 

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CamundaEventingIT.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CamundaEventingIT.java
@@ -1,0 +1,304 @@
+package org.camunda.bpm.spring.boot.starter;
+
+import org.assertj.core.util.DateUtil;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.impl.history.event.HistoricIdentityLinkLogEventEntity;
+import org.camunda.bpm.engine.impl.history.event.HistoricTaskInstanceEventEntity;
+import org.camunda.bpm.engine.impl.history.event.HistoryEvent;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.spring.boot.starter.test.nonpa.TestApplication;
+import org.camunda.bpm.spring.boot.starter.test.nonpa.TestEventCaptor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.transaction.Transactional;
+import java.util.Date;
+
+import static junit.framework.TestCase.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+  classes = {TestApplication.class},
+  webEnvironment = WebEnvironment.NONE,
+  properties = {"camunda.bpm.history-level=full"}
+)
+@Transactional
+public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
+
+  @Autowired
+  private RuntimeService runtime;
+
+  @Autowired
+  private TaskService taskService;
+
+  @Autowired
+  private TestEventCaptor eventCaptor;
+
+  private ProcessInstance instance;
+
+  @Before
+  public void init() {
+    ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery()
+      .processDefinitionKey("eventing")
+      .singleResult();
+    assertThat(processDefinition).isNotNull();
+
+    eventCaptor.historyEvents.clear();
+    instance = runtime.startProcessInstanceByKey("eventing");
+  }
+
+  @After
+  public void stop() {
+    if (instance != null) {
+      // update stale instance
+      instance = runtime.createProcessInstanceQuery().processInstanceId(instance.getProcessInstanceId()).active().singleResult();
+      if (instance != null) {
+        runtime.deleteProcessInstance(instance.getProcessInstanceId(), "eventing shutdown");
+      }
+    }
+  }
+
+  @Test
+  public final void should_event_task_creation() {
+    assertThat(eventCaptor.taskEvents).isNotEmpty();
+
+    Task task = taskService.createTaskQuery().active().singleResult();
+    TestEventCaptor.TaskEvent taskEvent = eventCaptor.taskEvents.pop();
+
+    assertThat(taskEvent.eventName).isEqualTo("create");
+    assertThat(taskEvent.id).isEqualTo(task.getId());
+    assertThat(taskEvent.processInstanceId).isEqualTo(task.getProcessInstanceId());
+  }
+
+  @Test
+  public final void should_event_task_assignment() {
+
+    // given
+    assertThat(eventCaptor.taskEvents).isNotEmpty();
+    eventCaptor.taskEvents.clear();
+    Task task = taskService.createTaskQuery().active().singleResult();
+
+    // when
+    taskService.setAssignee(task.getId(), "kermit");
+
+    // then
+    TestEventCaptor.TaskEvent taskEvent = eventCaptor.taskEvents.pop();
+    assertThat(taskEvent.eventName).isEqualTo("assignment");
+    assertThat(taskEvent.id).isEqualTo(task.getId());
+    assertThat(taskEvent.processInstanceId).isEqualTo(task.getProcessInstanceId());
+  }
+
+
+  @Test
+  public final void should_event_task_complete() {
+
+    // given
+    assertThat(eventCaptor.taskEvents).isNotEmpty();
+    eventCaptor.taskEvents.clear();
+    Task task = taskService.createTaskQuery().active().singleResult();
+
+    // when
+    taskService.complete(task.getId());
+
+    // then
+    TestEventCaptor.TaskEvent taskEvent = eventCaptor.taskEvents.pop();
+    assertThat(taskEvent.eventName).isEqualTo("complete");
+    assertThat(taskEvent.id).isEqualTo(task.getId());
+    assertThat(taskEvent.processInstanceId).isEqualTo(task.getProcessInstanceId());
+  }
+
+  @Test
+  public final void should_event_task_delete() {
+
+    // given
+    assertThat(eventCaptor.taskEvents).isNotEmpty();
+    eventCaptor.taskEvents.clear();
+    Task task = taskService.createTaskQuery().active().singleResult();
+
+    // when
+    runtimeService.deleteProcessInstance(instance.getProcessInstanceId(), "no need");
+
+    // then
+    TestEventCaptor.TaskEvent taskEvent = eventCaptor.taskEvents.pop();
+    assertThat(taskEvent.eventName).isEqualTo("delete");
+    assertThat(taskEvent.id).isEqualTo(task.getId());
+    assertThat(taskEvent.processInstanceId).isEqualTo(task.getProcessInstanceId());
+  }
+
+  @Test
+  public final void should_event_execution() {
+
+    // given
+    assertThat(eventCaptor.executionEvents).isNotEmpty();
+    eventCaptor.executionEvents.clear();
+    Task task = taskService.createTaskQuery().active().singleResult();
+
+    // when
+    taskService.complete(task.getId());
+
+    // then 7
+    // 2 for user task (start, end)
+    // 3 for service task (start, take, end)
+    // 2 for end event (start, end)
+    assertThat(eventCaptor.executionEvents.size()).isEqualTo(2 + 3 + 2);
+  }
+
+  @Test
+  public final void should_event_history_task_assignment_changes() {
+    // given
+    assertThat(eventCaptor.historyEvents).isNotEmpty();
+    eventCaptor.historyEvents.clear();
+    assertThat(eventCaptor.historyEvents).isEmpty();
+
+    Task task = taskService.createTaskQuery().active().singleResult();
+
+    // when
+    taskService.addCandidateUser(task.getId(), "userId");
+    taskService.addCandidateGroup(task.getId(), "groupId");
+    taskService.deleteCandidateUser(task.getId(), "userId");
+    taskService.deleteCandidateGroup(task.getId(), "groupId");
+
+    // then in reverse order
+
+    // Remove candidate group
+    HistoryEvent candidateGroupEvent = eventCaptor.historyEvents.pop();
+    assertThat(candidateGroupEvent.getEventType()).isEqualTo("delete-identity-link");
+    if (candidateGroupEvent instanceof HistoricIdentityLinkLogEventEntity) {
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateGroupEvent).getType()).isEqualTo("candidate");
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateGroupEvent).getOperationType()).isEqualTo("delete");
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateGroupEvent).getGroupId()).isEqualTo("groupId");
+    } else {
+      fail("Expected identity link log event");
+    }
+
+
+    // Remove candidate user
+    HistoryEvent candidateUserEvent = eventCaptor.historyEvents.pop();
+    assertThat(candidateUserEvent.getEventType()).isEqualTo("delete-identity-link");
+    if (candidateUserEvent instanceof HistoricIdentityLinkLogEventEntity) {
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateUserEvent).getType()).isEqualTo("candidate");
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateUserEvent).getOperationType()).isEqualTo("delete");
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateUserEvent).getUserId()).isEqualTo("userId");
+    } else {
+      fail("Expected identity link log event");
+    }
+
+    // Add candidate group
+    candidateGroupEvent = eventCaptor.historyEvents.pop();
+    assertThat(candidateGroupEvent.getEventType()).isEqualTo("add-identity-link");
+    if (candidateGroupEvent instanceof HistoricIdentityLinkLogEventEntity) {
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateGroupEvent).getType()).isEqualTo("candidate");
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateGroupEvent).getOperationType()).isEqualTo("add");
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateGroupEvent).getGroupId()).isEqualTo("groupId");
+    } else {
+      fail("Expected identity link log event");
+    }
+
+    // Add candidate user
+    candidateUserEvent = eventCaptor.historyEvents.pop();
+    assertThat(candidateUserEvent.getEventType()).isEqualTo("add-identity-link");
+    if (candidateUserEvent instanceof HistoricIdentityLinkLogEventEntity) {
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateUserEvent).getType()).isEqualTo("candidate");
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateUserEvent).getOperationType()).isEqualTo("add");
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateUserEvent).getUserId()).isEqualTo("userId");
+    } else {
+      fail("Expected identity link log event");
+    }
+
+    assertThat(eventCaptor.historyEvents).isEmpty();
+  }
+
+
+  @Test
+  public void should_event_history_task_attribute_changes() {
+    assertThat(eventCaptor.historyEvents).isNotEmpty();
+    eventCaptor.historyEvents.clear();
+
+    Task task = taskService.createTaskQuery().active().singleResult();
+
+    task.setName("new Name");
+    taskService.saveTask(task);
+
+
+    HistoryEvent taskChangeEvent = eventCaptor.historyEvents.pop();
+    assertThat(taskChangeEvent.getEventType()).isEqualTo("update");
+    if (taskChangeEvent instanceof HistoricTaskInstanceEventEntity) {
+      assertThat(((HistoricTaskInstanceEventEntity) taskChangeEvent).getName()).isEqualTo("new Name");
+    } else {
+      fail("Expected task instance change event");
+    }
+
+  }
+
+  @Test
+  public void should_event_history_task_multiple_assignment_changes() {
+
+    // given
+    assertThat(eventCaptor.historyEvents).isNotEmpty();
+    eventCaptor.historyEvents.clear();
+    assertThat(eventCaptor.historyEvents).isEmpty();
+
+    Task task = taskService.createTaskQuery().active().singleResult();
+
+    // when
+    taskService.addCandidateUser(task.getId(), "user1");
+    taskService.addCandidateUser(task.getId(), "user2");
+
+    // then in reverse order
+
+    // Add candidate user
+    HistoryEvent candidateUserEvent = eventCaptor.historyEvents.pop();
+    assertThat(candidateUserEvent.getEventType()).isEqualTo("add-identity-link");
+    if (candidateUserEvent instanceof HistoricIdentityLinkLogEventEntity) {
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateUserEvent).getType()).isEqualTo("candidate");
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateUserEvent).getOperationType()).isEqualTo("add");
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateUserEvent).getUserId()).isEqualTo("user2");
+    } else {
+      fail("Expected identity link log event");
+    }
+
+    // Add candidate user
+    candidateUserEvent = eventCaptor.historyEvents.pop();
+    assertThat(candidateUserEvent.getEventType()).isEqualTo("add-identity-link");
+    if (candidateUserEvent instanceof HistoricIdentityLinkLogEventEntity) {
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateUserEvent).getType()).isEqualTo("candidate");
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateUserEvent).getOperationType()).isEqualTo("add");
+      assertThat(((HistoricIdentityLinkLogEventEntity) candidateUserEvent).getUserId()).isEqualTo("user1");
+    } else {
+      fail("Expected identity link log event");
+    }
+
+    assertThat(eventCaptor.historyEvents).isEmpty();
+  }
+
+  @Test
+  public void should_event_history_task_follow_up_date_changes() {
+    assertThat(eventCaptor.historyEvents).isNotEmpty();
+    eventCaptor.historyEvents.clear();
+
+    Task task = taskService.createTaskQuery().active().singleResult();
+
+    Date now = DateUtil.now();
+
+    task.setFollowUpDate(now);
+    taskService.saveTask(task);
+
+    HistoryEvent taskChangeEvent = eventCaptor.historyEvents.pop();
+    assertThat(taskChangeEvent.getEventType()).isEqualTo("update");
+    if (taskChangeEvent instanceof HistoricTaskInstanceEventEntity) {
+      assertThat(((HistoricTaskInstanceEventEntity) taskChangeEvent).getFollowUpDate()).isEqualTo(now);
+    } else {
+      fail("Expected task instance change event");
+    }
+  }
+}

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CamundaEventingIT.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CamundaEventingIT.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2015-2019 camunda services GmbH and various authors (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.spring.boot.starter;
 
 import org.assertj.core.util.DateUtil;

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultDeploymentConfigurationTest.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultDeploymentConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2018 camunda services GmbH and various authors (info@camunda.com)
+ * Copyright © 2015-2019 camunda services GmbH and various authors (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/property/EventingPropertyTest.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/property/EventingPropertyTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015-2019 camunda services GmbH and various authors (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.property;
+
+import org.camunda.bpm.engine.identity.User;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {
+  "camunda.bpm.eventing.execution=false",
+  "camunda.bpm.eventing.task=false",
+  "camunda.bpm.eventing.history=false"})
+public class EventingPropertyTest extends ParsePropertiesHelper {
+
+  @Test
+  public void shouldLoadProperties() {
+    assertThat(properties.getEventing().isExecution()).isFalse();
+    assertThat(properties.getEventing().isTask()).isFalse();
+    assertThat(properties.getEventing().isHistory()).isFalse();
+  }
+
+}

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/nonpa/EventingServiceTask.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/nonpa/EventingServiceTask.java
@@ -1,0 +1,14 @@
+package org.camunda.bpm.spring.boot.starter.test.nonpa;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.springframework.stereotype.Component;
+
+@Component("eventingServiceTask")
+public class EventingServiceTask implements JavaDelegate {
+
+  @Override
+  public void execute(DelegateExecution delegateExecution) throws Exception {
+    // NOTHING TO DO HERE
+  }
+}

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/nonpa/EventingServiceTask.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/nonpa/EventingServiceTask.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2015-2019 camunda services GmbH and various authors (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.spring.boot.starter.test.nonpa;
 
 import org.camunda.bpm.engine.delegate.DelegateExecution;

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/nonpa/TestEventCaptor.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/nonpa/TestEventCaptor.java
@@ -1,0 +1,57 @@
+package org.camunda.bpm.spring.boot.starter.test.nonpa;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.DelegateTask;
+import org.camunda.bpm.engine.impl.history.event.HistoryEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.Stack;
+
+@Component
+public class TestEventCaptor {
+
+  public Stack<HistoryEvent> historyEvents = new Stack<>();
+  public Stack<TaskEvent> taskEvents = new Stack<>();
+  public Stack<ExecutionEvent> executionEvents = new Stack<>();
+
+  @EventListener
+  public void onEvent(HistoryEvent event) {
+    historyEvents.push(event);
+  }
+
+  @EventListener
+  public void onEvent(DelegateExecution event) {
+    executionEvents.push(new ExecutionEvent(event));
+  }
+
+  @EventListener
+  public void onEvent(DelegateTask event) {
+    taskEvents.push(new TaskEvent(event));
+  }
+
+  public static class ExecutionEvent {
+    public final String id;
+    public final String processInstanceId;
+    public final String activityId;
+
+    public ExecutionEvent(DelegateExecution execution) {
+      this.id = execution.getId();
+      this.processInstanceId = execution.getProcessInstanceId();
+      this.activityId = execution.getCurrentActivityId();
+    }
+  }
+
+  public static class TaskEvent {
+    public final String id;
+    public final String processInstanceId;
+    public final String eventName;
+
+    public TaskEvent(DelegateTask task) {
+      this.id = task.getId();
+      this.processInstanceId = task.getProcessInstanceId();
+      this.eventName = task.getEventName();
+    }
+  }
+
+}

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/nonpa/TestEventCaptor.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/nonpa/TestEventCaptor.java
@@ -49,11 +49,13 @@ public class TestEventCaptor {
     public final String id;
     public final String processInstanceId;
     public final String activityId;
+    public final String eventName;
 
     public ExecutionEvent(DelegateExecution execution) {
       this.id = execution.getId();
       this.processInstanceId = execution.getProcessInstanceId();
       this.activityId = execution.getCurrentActivityId();
+      this.eventName = execution.getEventName();
     }
   }
 

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/nonpa/TestEventCaptor.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/nonpa/TestEventCaptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2015-2019 camunda services GmbH and various authors (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.spring.boot.starter.test.nonpa;
 
 import org.camunda.bpm.engine.delegate.DelegateExecution;

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/pa/TestProcessApplication.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/pa/TestProcessApplication.java
@@ -4,6 +4,8 @@ import org.camunda.bpm.spring.boot.starter.annotation.EnableProcessApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 /**
+ * Test process application.
+ *
  * @author Svetlana Dorokhova.
  */
 @SpringBootApplication

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/pa/TestProcessApplication.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/pa/TestProcessApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2018 camunda services GmbH and various authors (info@camunda.com)
+ * Copyright © 2015-2019 camunda services GmbH and various authors (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter/src/test/resources/application-eventing.properties
+++ b/starter/src/test/resources/application-eventing.properties
@@ -1,0 +1,5 @@
+camunda.bpm.history-level=full
+
+camunda.bpm.eventing.execution=true
+camunda.bpm.eventing.history=true
+camunda.bpm.eventing.task=true

--- a/starter/src/test/resources/application-noeventing.properties
+++ b/starter/src/test/resources/application-noeventing.properties
@@ -1,0 +1,5 @@
+camunda.bpm.history-level=full
+
+camunda.bpm.eventing.execution=false
+camunda.bpm.eventing.history=false
+camunda.bpm.eventing.task=false

--- a/starter/src/test/resources/bpmn/eventing.bpmn
+++ b/starter/src/test/resources/bpmn/eventing.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1lmgbl7" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.2.4">
+  <bpmn:process id="eventing" name="eventing" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0ndk8rv</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0ndk8rv" sourceRef="StartEvent_1" targetRef="user_task" />
+    <bpmn:userTask id="user_task" name="execute&#10;user task">
+      <bpmn:incoming>SequenceFlow_0ndk8rv</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0mjrja8</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0mjrja8" sourceRef="user_task" targetRef="service_task" />
+    <bpmn:serviceTask id="service_task" name="execute service&#10;task" camunda:delegateExpression="${eventingServiceTask}">
+      <bpmn:incoming>SequenceFlow_0mjrja8</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1juyzhf</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_11s18x7">
+      <bpmn:incoming>SequenceFlow_1juyzhf</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1juyzhf" sourceRef="service_task" targetRef="EndEvent_11s18x7" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="eventing">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="258" y="161" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ndk8rv_di" bpmnElement="SequenceFlow_0ndk8rv">
+        <di:waypoint x="294" y="179" />
+        <di:waypoint x="344" y="179" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_0zqz51t_di" bpmnElement="user_task">
+        <dc:Bounds x="344" y="139" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0mjrja8_di" bpmnElement="SequenceFlow_0mjrja8">
+        <di:waypoint x="444" y="179" />
+        <di:waypoint x="494" y="179" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_1a8uu7u_di" bpmnElement="service_task">
+        <dc:Bounds x="494" y="139" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_11s18x7_di" bpmnElement="EndEvent_11s18x7">
+        <dc:Bounds x="644" y="161" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1juyzhf_di" bpmnElement="SequenceFlow_1juyzhf">
+        <di:waypoint x="594" y="179" />
+        <di:waypoint x="644" y="179" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
like camunda-bpm-reactor this allows execution of task/execution listeners via eventing without changing the models.
see https://app.camunda.com/jira/browse/CAM-8965


this PR is not finished, I just wanted to publish early so we can discuss if this is worth to carry on