### PR TITLE
fix(pom): set scope "test" for camunda-bpm-spring-boot-starter-test

### DIFF
--- a/starter-rest/pom.xml
+++ b/starter-rest/pom.xml
@@ -44,6 +44,7 @@
       <artifactId>camunda-bpm-spring-boot-starter-test</artifactId>
       <groupId>${project.groupId}</groupId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This dependency is test-only and thus should not be in compile scope
(see POMs of other Camunda Spring Boot starters, e.g. starter-webapp)