### PR TITLE
CAM-9972: feat(spring-boot): add jackson java 8 modules for spin

### DIFF
--- a/starter-qa/integration-test-plugins/pom.xml
+++ b/starter-qa/integration-test-plugins/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.camunda.bpm.springboot.project</groupId>
+    <artifactId>camunda-bpm-spring-boot-starter-qa</artifactId>
+    <version>3.4.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <packaging>pom</packaging>
+
+  <artifactId>qa-plugins</artifactId>
+
+  <dependencyManagement>
+
+    <dependencies>
+
+      <dependency>
+        <groupId>org.camunda.bpm.springboot</groupId>
+        <artifactId>camunda-bpm-spring-boot-starter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.camunda.bpm.springboot</groupId>
+        <artifactId>camunda-bpm-spring-boot-starter-test</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.camunda.bpm</groupId>
+        <artifactId>camunda-engine-plugin-spin</artifactId>
+        <version>${camunda.version}</version>
+      </dependency>
+
+    </dependencies>
+
+  </dependencyManagement>
+
+  <modules>
+    <module>spin</module>
+  </modules>
+
+</project>

--- a/starter-qa/integration-test-plugins/spin/pom.xml
+++ b/starter-qa/integration-test-plugins/spin/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.camunda.bpm.springboot.project</groupId>
+    <artifactId>qa-plugins</artifactId>
+    <version>3.4.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>qa-plugins-spin</artifactId>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.camunda.bpm.springboot</groupId>
+      <artifactId>camunda-bpm-spring-boot-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.bpm.springboot</groupId>
+      <artifactId>camunda-bpm-spring-boot-starter-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.bpm</groupId>
+      <artifactId>camunda-engine-plugin-spin</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.spin</groupId>
+      <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <id>pre-integration-test</id>
+            <goals>
+              <goal>start</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>post-integration-test</id>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinApplication.java
+++ b/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinApplication.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.springboot.project.qa.spin;
 
 import static org.camunda.spin.Spin.S;

--- a/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinApplication.java
+++ b/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinApplication.java
@@ -1,0 +1,29 @@
+package org.camunda.bpm.springboot.project.qa.spin;
+
+import static org.camunda.spin.Spin.S;
+
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.camunda.spin.json.SpinJsonNode;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class SpinApplication {
+
+  @Bean
+  public JavaDelegate spinJava8DeserializerDelegate() {
+    return delegateExecution -> {
+      SpinJsonNode jsonNode = S("{\"dateTime\": \"2019-12-12T22:22:22\"}");
+      Object         key      = jsonNode.mapTo(SpinJava8Dto.class);
+    };
+  }
+
+  @Bean
+  public JavaDelegate spinDeserializerDelegate() {
+    return delegateExecution -> {
+      SpinJsonNode jsonNode = S("{\"dateTime\": \"2019-12-12T22:22:22\"}");
+      Object         key      = jsonNode.mapTo(SpinDto.class);
+      delegateExecution.setVariable("dateTime", key);
+    };
+  }
+}

--- a/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinApplicationTestIT.java
+++ b/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinApplicationTestIT.java
@@ -1,0 +1,47 @@
+package org.camunda.bpm.springboot.project.qa.spin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.RuntimeService;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { SpinApplication.class },
+                webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class SpinApplicationTestIT {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Autowired
+  RuntimeService runtimeService;
+
+  @Autowired
+  HistoryService historyService;
+
+  @Test
+  public void shouldDeserializeSuccessfully() {
+    // when
+    runtimeService.startProcessInstanceByKey("spinServiceProcess");
+
+    // then
+    long variableCount = historyService.createHistoricVariableInstanceQuery().count();
+    assertThat(variableCount).isOne();
+  }
+
+  @Test
+  public void shouldFailWithSpinException() {
+    // given
+    thrown.expectMessage("SPIN/JACKSON-JSON-01006 Cannot deserialize");
+
+    // when
+    runtimeService.startProcessInstanceByKey("spinJava8ServiceProcess");
+  }
+}

--- a/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinApplicationTestIT.java
+++ b/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinApplicationTestIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.springboot.project.qa.spin;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinDto.java
+++ b/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinDto.java
@@ -1,0 +1,17 @@
+package org.camunda.bpm.springboot.project.qa.spin;
+
+import java.sql.Date;
+
+public class SpinDto {
+
+  protected Date dateTime;
+
+  public Date getDateTime() {
+    return dateTime;
+  }
+
+  public void setDateTime(Date dateTime) {
+    this.dateTime = dateTime;
+  }
+
+}

--- a/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinDto.java
+++ b/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinDto.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.springboot.project.qa.spin;
 
 import java.sql.Date;

--- a/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinJava8Dto.java
+++ b/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinJava8Dto.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.springboot.project.qa.spin;
 
 import java.time.LocalDateTime;

--- a/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinJava8Dto.java
+++ b/starter-qa/integration-test-plugins/spin/src/test/java/org/camunda/bpm/springboot/project/qa/spin/SpinJava8Dto.java
@@ -1,0 +1,17 @@
+package org.camunda.bpm.springboot.project.qa.spin;
+
+import java.time.LocalDateTime;
+
+public class SpinJava8Dto {
+
+  protected LocalDateTime dateTime;
+
+  public LocalDateTime getDateTime() {
+    return dateTime;
+  }
+
+  public void setDateTime(LocalDateTime dateTime) {
+    this.dateTime = dateTime;
+  }
+
+}

--- a/starter-qa/integration-test-plugins/spin/src/test/resources/spin-java8-model.bpmn
+++ b/starter-qa/integration-test-plugins/spin/src/test/resources/spin-java8-model.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_04y1ds8" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.3.4">
+  <bpmn:process id="spinJava8ServiceProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_110juaz</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_110juaz" sourceRef="StartEvent_1" targetRef="Task_0x8lay6" />
+    <bpmn:endEvent id="EndEvent_0hgnwnx">
+      <bpmn:incoming>SequenceFlow_13uh5xc</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_13uh5xc" sourceRef="Task_0x8lay6" targetRef="EndEvent_0hgnwnx" />
+    <bpmn:serviceTask id="Task_0x8lay6" name="Spin Service Task" camunda:delegateExpression="${spinJava8DeserializerDelegate}">
+      <bpmn:incoming>SequenceFlow_110juaz</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_13uh5xc</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1w2sopo">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_110juaz_di" bpmnElement="SequenceFlow_110juaz">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0hgnwnx_di" bpmnElement="EndEvent_0hgnwnx">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_13uh5xc_di" bpmnElement="SequenceFlow_13uh5xc">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_1vklp85_di" bpmnElement="Task_0x8lay6">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/starter-qa/integration-test-plugins/spin/src/test/resources/spin-model.bpmn
+++ b/starter-qa/integration-test-plugins/spin/src/test/resources/spin-model.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_04y1ds8" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.3.4">
+  <bpmn:process id="spinServiceProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_110juaz</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_110juaz" sourceRef="StartEvent_1" targetRef="Task_0x8lay6" />
+    <bpmn:endEvent id="EndEvent_0hgnwnx">
+      <bpmn:incoming>SequenceFlow_13uh5xc</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_13uh5xc" sourceRef="Task_0x8lay6" targetRef="EndEvent_0hgnwnx" />
+    <bpmn:serviceTask id="Task_0x8lay6" name="Spin Service Task" camunda:delegateExpression="${spinDeserializerDelegate}">
+      <bpmn:incoming>SequenceFlow_110juaz</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_13uh5xc</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1w2sopo">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_110juaz_di" bpmnElement="SequenceFlow_110juaz">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0hgnwnx_di" bpmnElement="EndEvent_0hgnwnx">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_13uh5xc_di" bpmnElement="SequenceFlow_13uh5xc">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_1vklp85_di" bpmnElement="Task_0x8lay6">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/starter-qa/pom.xml
+++ b/starter-qa/pom.xml
@@ -18,6 +18,7 @@
 
   <modules>
     <module>integration-test-webapp</module>
+    <module>integration-test-plugins</module>
   </modules>
 
 </project>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -14,7 +14,7 @@
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine-spring</artifactId>
     </dependency>
-    
+
     <!-- Spring dependencies required by camunda-engine-spring -->
     <dependency>
       <groupId>org.springframework</groupId>
@@ -36,6 +36,12 @@
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine-plugin-spin</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.spin</groupId>
+      <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
       <optional>true</optional>
     </dependency>
 
@@ -85,7 +91,7 @@
       <artifactId>spring-boot-starter-security</artifactId>
       <optional>true</optional>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmPluginConfiguration.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmPluginConfiguration.java
@@ -16,12 +16,17 @@
  */
 package org.camunda.bpm.spring.boot.starter;
 
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.camunda.bpm.engine.impl.cfg.ProcessEnginePlugin;
+import org.camunda.bpm.spring.boot.starter.spin.CamundaJacksonFormatConfiguratorJSR310;
+import org.camunda.bpm.spring.boot.starter.spin.CamundaJacksonFormatConfiguratorJdk8;
+import org.camunda.bpm.spring.boot.starter.spin.CamundaJacksonFormatConfiguratorParameterNames;
+import org.camunda.bpm.spring.boot.starter.spin.SpringBootSpinProcessEnginePlugin;
 import org.camunda.connect.plugin.impl.ConnectProcessEnginePlugin;
 import org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormat;
 import org.camunda.spin.plugin.impl.SpinProcessEnginePlugin;
-import org.camunda.spin.spi.DataFormatConfigurator;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -30,6 +35,42 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class CamundaBpmPluginConfiguration {
 
+  @ConditionalOnClass({JacksonJsonDataFormat.class, JavaTimeModule.class})
+  @Configuration
+  static class SpinDataFormatConfigurationJSR310 {
+
+    @Bean
+    @ConditionalOnMissingBean(name = "spinDataFormatConfiguratorJSR310")
+    public static CamundaJacksonFormatConfiguratorJSR310 spinDataFormatConfiguratorJSR310() {
+      return new CamundaJacksonFormatConfiguratorJSR310();
+    }
+
+  }
+
+  @ConditionalOnClass({JacksonJsonDataFormat.class, ParameterNamesModule.class})
+  @Configuration
+  static class SpinDataFormatConfigurationParameterNames {
+
+    @Bean
+    @ConditionalOnMissingBean(name = "spinDataFormatConfiguratorParameterNames")
+    public static CamundaJacksonFormatConfiguratorParameterNames spinDataFormatConfiguratorParameterNames() {
+      return new CamundaJacksonFormatConfiguratorParameterNames();
+    }
+
+  }
+
+  @ConditionalOnClass({JacksonJsonDataFormat.class, Jdk8Module.class})
+  @Configuration
+  static class SpinDataFormatConfigurationJdk8 {
+
+    @Bean
+    @ConditionalOnMissingBean(name = "spinDataFormatConfiguratorJdk8")
+    public static CamundaJacksonFormatConfiguratorJdk8 spinDataFormatConfiguratorJdk8() {
+      return new CamundaJacksonFormatConfiguratorJdk8();
+    }
+
+  }
+
   @ConditionalOnClass(SpinProcessEnginePlugin.class)
   @Configuration
   static class SpinConfiguration {
@@ -37,19 +78,9 @@ public class CamundaBpmPluginConfiguration {
     @Bean
     @ConditionalOnMissingBean(name = "spinProcessEnginePlugin")
     public static ProcessEnginePlugin spinProcessEnginePlugin() {
-      return new SpinProcessEnginePlugin();
+      return new SpringBootSpinProcessEnginePlugin();
     }
 
-    @Configuration
-    @ConditionalOnBean(name = "spinProcessEnginePlugin")
-    @ConditionalOnClass(name = "org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormat")
-    static class CamundaJacksonFormatConfiguraton {
-
-      @Bean
-      public DataFormatConfigurator<JacksonJsonDataFormat> dataFormatConfigurator() {
-        return new CamundaJacksonFormatConfigurator();
-      }
-    }
   }
 
   @ConditionalOnClass(ConnectProcessEnginePlugin.class)

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmPluginConfiguration.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaBpmPluginConfiguration.java
@@ -18,7 +18,10 @@ package org.camunda.bpm.spring.boot.starter;
 
 import org.camunda.bpm.engine.impl.cfg.ProcessEnginePlugin;
 import org.camunda.connect.plugin.impl.ConnectProcessEnginePlugin;
+import org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormat;
 import org.camunda.spin.plugin.impl.SpinProcessEnginePlugin;
+import org.camunda.spin.spi.DataFormatConfigurator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -35,6 +38,17 @@ public class CamundaBpmPluginConfiguration {
     @ConditionalOnMissingBean(name = "spinProcessEnginePlugin")
     public static ProcessEnginePlugin spinProcessEnginePlugin() {
       return new SpinProcessEnginePlugin();
+    }
+
+    @Configuration
+    @ConditionalOnBean(name = "spinProcessEnginePlugin")
+    @ConditionalOnClass(name = "org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormat")
+    static class CamundaJacksonFormatConfiguraton {
+
+      @Bean
+      public DataFormatConfigurator<JacksonJsonDataFormat> dataFormatConfigurator() {
+        return new CamundaJacksonFormatConfigurator();
+      }
     }
   }
 

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaJacksonFormatConfigurator.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/CamundaJacksonFormatConfigurator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormat;
+import org.camunda.spin.spi.DataFormatConfigurator;
+
+public class CamundaJacksonFormatConfigurator implements DataFormatConfigurator<JacksonJsonDataFormat> {
+
+  @Override
+  public Class<JacksonJsonDataFormat> getDataFormatClass() {
+    return JacksonJsonDataFormat.class;
+  }
+
+  @Override
+  public void configure(JacksonJsonDataFormat dataFormat) {
+    ObjectMapper mapper = dataFormat.getObjectMapper();
+
+    mapper.registerModule(new JavaTimeModule());
+    mapper.registerModule(new ParameterNamesModule());
+    mapper.registerModule(new Jdk8Module());
+  }
+}

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/spin/CamundaJacksonFormatConfiguratorJSR310.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/spin/CamundaJacksonFormatConfiguratorJSR310.java
@@ -14,16 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.camunda.bpm.spring.boot.starter;
+package org.camunda.bpm.spring.boot.starter.spin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormat;
 import org.camunda.spin.spi.DataFormatConfigurator;
 
-public class CamundaJacksonFormatConfigurator implements DataFormatConfigurator<JacksonJsonDataFormat> {
+
+public class CamundaJacksonFormatConfiguratorJSR310 implements DataFormatConfigurator<JacksonJsonDataFormat> {
 
   @Override
   public Class<JacksonJsonDataFormat> getDataFormatClass() {
@@ -33,9 +32,8 @@ public class CamundaJacksonFormatConfigurator implements DataFormatConfigurator<
   @Override
   public void configure(JacksonJsonDataFormat dataFormat) {
     ObjectMapper mapper = dataFormat.getObjectMapper();
+    final JavaTimeModule javaTimeModule = new JavaTimeModule();
 
-    mapper.registerModule(new JavaTimeModule());
-    mapper.registerModule(new ParameterNamesModule());
-    mapper.registerModule(new Jdk8Module());
+    mapper.registerModule(javaTimeModule);
   }
 }

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/spin/CamundaJacksonFormatConfiguratorJdk8.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/spin/CamundaJacksonFormatConfiguratorJdk8.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.spin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormat;
+import org.camunda.spin.spi.DataFormatConfigurator;
+
+
+public class CamundaJacksonFormatConfiguratorJdk8 implements DataFormatConfigurator<JacksonJsonDataFormat> {
+
+  @Override
+  public Class<JacksonJsonDataFormat> getDataFormatClass() {
+    return JacksonJsonDataFormat.class;
+  }
+
+  @Override
+  public void configure(JacksonJsonDataFormat dataFormat) {
+    ObjectMapper mapper = dataFormat.getObjectMapper();
+    final Jdk8Module jdk8Module = new Jdk8Module();
+
+    mapper.registerModule(jdk8Module);
+  }
+}

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/spin/CamundaJacksonFormatConfiguratorParameterNames.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/spin/CamundaJacksonFormatConfiguratorParameterNames.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.spin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormat;
+import org.camunda.spin.spi.DataFormatConfigurator;
+
+
+public class CamundaJacksonFormatConfiguratorParameterNames implements DataFormatConfigurator<JacksonJsonDataFormat> {
+
+  @Override
+  public Class<JacksonJsonDataFormat> getDataFormatClass() {
+    return JacksonJsonDataFormat.class;
+  }
+
+  @Override
+  public void configure(JacksonJsonDataFormat dataFormat) {
+    ObjectMapper mapper = dataFormat.getObjectMapper();
+    final ParameterNamesModule parameterNamesModule = new ParameterNamesModule();
+
+    mapper.registerModule(parameterNamesModule);
+  }
+}

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/spin/SpringBootSpinProcessEnginePlugin.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/spin/SpringBootSpinProcessEnginePlugin.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.spin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.util.ClassLoaderUtil;
+import org.camunda.spin.DataFormats;
+import org.camunda.spin.plugin.impl.SpinProcessEnginePlugin;
+import org.camunda.spin.spi.DataFormatConfigurator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.support.SpringFactoriesLoader;
+
+public class SpringBootSpinProcessEnginePlugin extends SpinProcessEnginePlugin {
+
+  @Autowired
+  protected Optional<CamundaJacksonFormatConfiguratorJSR310> dataFormatConfiguratorJsr310;
+
+  @Autowired
+  protected Optional<CamundaJacksonFormatConfiguratorParameterNames> dataFormatConfiguratorParameterNames;
+
+  @Autowired
+  protected Optional<CamundaJacksonFormatConfiguratorJdk8> dataFormatConfiguratorJdk8;
+
+  @Override
+  public void preInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
+    super.preInit(processEngineConfiguration);
+
+    // After any DataFormats are loaded through SPI, additionally execute
+    // configurators through Spring beans and Spring Factories
+    ClassLoader classloader = ClassLoaderUtil.getClassloader(SpringBootSpinProcessEnginePlugin.class);
+    loadSpringBootDataFormats(classloader);
+  }
+
+  protected void loadSpringBootDataFormats(ClassLoader classloader) {
+    List<DataFormatConfigurator> configurators = new ArrayList<>();
+
+    // add the auto-config Jackson Java 8 module configurators
+    dataFormatConfiguratorJsr310.ifPresent(configurator -> configurators.add(configurator));
+    dataFormatConfiguratorParameterNames.ifPresent(configurator -> configurators.add(configurator));
+    dataFormatConfiguratorJdk8.ifPresent(configurator -> configurators.add(configurator));
+
+    // next, add any configurators defined in the spring.factories file
+    configurators.addAll(SpringFactoriesLoader.loadFactories(DataFormatConfigurator.class, classloader));
+
+    for (DataFormatConfigurator configurator : configurators) {
+      DataFormats.applyConfigurator(configurator);
+    }
+  }
+}

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/spin/SpringBootSpinProcessEnginePlugin.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/spin/SpringBootSpinProcessEnginePlugin.java
@@ -41,10 +41,6 @@ public class SpringBootSpinProcessEnginePlugin extends SpinProcessEnginePlugin {
 
   @Override
   public void preInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
-    super.preInit(processEngineConfiguration);
-
-    // After any DataFormats are loaded through SPI, additionally execute
-    // configurators through Spring beans and Spring Factories
     ClassLoader classloader = ClassLoaderUtil.getClassloader(SpringBootSpinProcessEnginePlugin.class);
     loadSpringBootDataFormats(classloader);
   }
@@ -60,8 +56,6 @@ public class SpringBootSpinProcessEnginePlugin extends SpinProcessEnginePlugin {
     // next, add any configurators defined in the spring.factories file
     configurators.addAll(SpringFactoriesLoader.loadFactories(DataFormatConfigurator.class, classloader));
 
-    for (DataFormatConfigurator configurator : configurators) {
-      DataFormats.applyConfigurator(configurator);
-    }
+    DataFormats.loadDataFormats(classloader, configurators);
   }
 }

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultDeploymentConfigurationTest.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultDeploymentConfigurationTest.java
@@ -53,11 +53,11 @@ public class DefaultDeploymentConfigurationTest {
     defaultDeploymentConfiguration.preInit(configuration);
 
     final Resource[] resources = configuration.getDeploymentResources();
-    assertThat(resources).hasSize(8);
+    assertThat(resources).hasSize(9);
 
     assertThat(filenames(resources)).containsOnly("async-service-task.bpmn", "test.cmmn10.xml",
       "test.bpmn", "test.cmmn", "test.bpmn20.xml", "check-order.dmn", "eventing.bpmn",
-      "spin-java8-model.bpmn");
+      "spin-java8-model.bpmn", "eventingWithTaskAssignee.bpmn");
   }
 
   private Set<String> filenames(Resource[] resources) {

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultDeploymentConfigurationTest.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultDeploymentConfigurationTest.java
@@ -53,9 +53,11 @@ public class DefaultDeploymentConfigurationTest {
     defaultDeploymentConfiguration.preInit(configuration);
 
     final Resource[] resources = configuration.getDeploymentResources();
-    assertThat(resources).hasSize(7);
+    assertThat(resources).hasSize(8);
 
-    assertThat(filenames(resources)).containsOnly("async-service-task.bpmn", "test.cmmn10.xml", "test.bpmn", "test.cmmn", "test.bpmn20.xml", "check-order.dmn", "eventing.bpmn");
+    assertThat(filenames(resources)).containsOnly("async-service-task.bpmn", "test.cmmn10.xml",
+      "test.bpmn", "test.cmmn", "test.bpmn20.xml", "check-order.dmn", "eventing.bpmn",
+      "spin-java8-model.bpmn");
   }
 
   private Set<String> filenames(Resource[] resources) {

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/plugin/spin/SpinApplication.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/plugin/spin/SpinApplication.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.spring.boot.starter.plugin.spin;
 
 import static org.camunda.spin.Spin.S;

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/plugin/spin/SpinApplication.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/plugin/spin/SpinApplication.java
@@ -1,0 +1,21 @@
+package org.camunda.bpm.spring.boot.starter.plugin.spin;
+
+import static org.camunda.spin.Spin.S;
+
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.camunda.spin.json.SpinJsonNode;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class SpinApplication {
+
+  @Bean
+  public JavaDelegate spinJava8DeserializerDelegate() {
+    return delegateExecution -> {
+      SpinJsonNode jsonNode = S("{\"dateTime\": \"2019-12-12T22:22:22\"}");
+      Object         key      = jsonNode.mapTo(SpinJava8Dto.class);
+      delegateExecution.setVariable("dateTime", key);
+    };
+  }
+}

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/plugin/spin/SpinApplicationTestIT.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/plugin/spin/SpinApplicationTestIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.spring.boot.starter.plugin.spin;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/plugin/spin/SpinApplicationTestIT.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/plugin/spin/SpinApplicationTestIT.java
@@ -1,0 +1,34 @@
+package org.camunda.bpm.spring.boot.starter.plugin.spin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.RuntimeService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { SpinApplication.class },
+                webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class SpinApplicationTestIT {
+
+  @Autowired
+  RuntimeService runtimeService;
+
+  @Autowired
+  HistoryService historyService;
+
+  @Test
+  public void shouldDeserializeSuccessfully() {
+    // when
+    runtimeService.startProcessInstanceByKey("spinJava8ServiceProcess");
+
+    // then
+    long variableCount = historyService.createHistoricVariableInstanceQuery().count();
+    assertThat(variableCount).isOne();
+  }
+
+}

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/plugin/spin/SpinJava8Dto.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/plugin/spin/SpinJava8Dto.java
@@ -1,0 +1,17 @@
+package org.camunda.bpm.spring.boot.starter.plugin.spin;
+
+import java.time.LocalDateTime;
+
+public class SpinJava8Dto {
+
+  protected LocalDateTime dateTime;
+
+  public LocalDateTime getDateTime() {
+    return dateTime;
+  }
+
+  public void setDateTime(LocalDateTime dateTime) {
+    this.dateTime = dateTime;
+  }
+
+}

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/plugin/spin/SpinJava8Dto.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/plugin/spin/SpinJava8Dto.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.spring.boot.starter.plugin.spin;
 
 import java.time.LocalDateTime;

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/nonpa/TestApplication.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/test/nonpa/TestApplication.java
@@ -16,11 +16,37 @@
  */
 package org.camunda.bpm.spring.boot.starter.test.nonpa;
 
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.cfg.ProcessEnginePlugin;
+import org.camunda.spin.plugin.impl.SpinProcessEnginePlugin;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @SpringBootApplication
 @EnableTransactionManagement
 public class TestApplication {
 
+  @ConditionalOnProperty(prefix = "camunda.bpm.jpa", name = "enabled", havingValue = "false")
+  @Configuration
+  public class TestConfiguration {
+
+    @Bean(name = "spinProcessEnginePlugin")
+    public ProcessEnginePlugin spinProcessEnginePlugin() {
+      return new SpinProcessEnginePlugin() {
+
+        // When testing the NoJpaAutoConfigurationIT test, ensure that no Custom DataFormat
+        // Serializers are loaded, otherwise the test's assumption will fail
+        @Override
+        public void postInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
+          registerFunctionMapper(processEngineConfiguration);
+          registerScriptResolver(processEngineConfiguration);
+          registerValueTypes(processEngineConfiguration);
+          registerFallbackSerializer(processEngineConfiguration);
+        }
+      };
+    }
+  }
 }

--- a/starter/src/test/resources/bpmn/spin-java8-model.bpmn
+++ b/starter/src/test/resources/bpmn/spin-java8-model.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_04y1ds8" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.3.4">
+  <bpmn:process id="spinJava8ServiceProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_110juaz</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_110juaz" sourceRef="StartEvent_1" targetRef="Task_0x8lay6" />
+    <bpmn:endEvent id="EndEvent_0hgnwnx">
+      <bpmn:incoming>SequenceFlow_13uh5xc</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_13uh5xc" sourceRef="Task_0x8lay6" targetRef="EndEvent_0hgnwnx" />
+    <bpmn:serviceTask id="Task_0x8lay6" name="Spin Service Task" camunda:delegateExpression="${spinJava8DeserializerDelegate}">
+      <bpmn:incoming>SequenceFlow_110juaz</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_13uh5xc</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1w2sopo">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_110juaz_di" bpmnElement="SequenceFlow_110juaz">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0hgnwnx_di" bpmnElement="EndEvent_0hgnwnx">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_13uh5xc_di" bpmnElement="SequenceFlow_13uh5xc">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_1vklp85_di" bpmnElement="Task_0x8lay6">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Design decisions:

* Add the `camunda-spin-dataformat-json-jackson` dependency as optional. This way, the user will need to explicitly declare it for the dependency to be added on the classpath;
* Create a `CamundaJacksonFormatConfigurator` bean on the condition that the `JacksonJsonDataFormat` class is present on the classpath. The class is available from the above-mentioned dependency;
* Register the Jackson Java 8 modules in the new `CamundaJacksonFormatConfigurator` class.
* We don't need to use SPI since the configuration will be registered through the `CamundaBpmAutoConfiguration` class in the `spring.factories file`. See the spring docs [here](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-developing-auto-configuration.html#boot-features-class-conditions) for why a separate class with a Configuration annotation is needed.
* Spring Boot already provides Jackson configuration properties. See [here](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#howto-customize-the-jackson-objectmapper) for more details.

Issues and solutions:
The `CamundaNoJpaAutoConfigurationIT` test started failing since it operates on the assumption that no Spin DataFormat Serializers are available. This happens because, by adding the `camunda-spin-dataformat-json-jackson` dependency, the serializers are automatically loaded. I solved the problem by adding a `TestConfiguration` class in `TestApplication` that disables serializer registration in the `SpinProcessEnginePlugin` when JPA is disabled.


Related to CAM-9972: https://app.camunda.com/jira/browse/CAM-9972