### PR TITLE
CAM-10588: dispatch immutable events additionally

### DIFF
--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/ExecutionEvent.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/ExecutionEvent.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.event;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.ExecutionListener;
+
+public class ExecutionEvent {
+
+  protected String activityInstanceId;
+  protected String businessKey;
+  protected String currentActivityId;
+  protected String currentActivityName;
+  protected String currentTransitionId;
+  protected String eventName;
+  protected String id;
+  protected String parentActivityInstanceId;
+  protected String parentId;
+  protected String processBusinessKey;
+  protected String processDefinitionId;
+  protected String processInstanceId;
+  protected String tenantId;
+
+  public ExecutionEvent(DelegateExecution delegateExecution) {
+    this.activityInstanceId = delegateExecution.getActivityInstanceId();
+    this.businessKey = delegateExecution.getBusinessKey();
+    this.currentActivityId = delegateExecution.getCurrentActivityId();
+    this.currentActivityName = delegateExecution.getCurrentActivityName();
+    this.currentTransitionId = delegateExecution.getCurrentTransitionId();
+    this.eventName = delegateExecution.getEventName();
+    this.id = delegateExecution.getId();
+    this.parentActivityInstanceId = delegateExecution.getParentActivityInstanceId();
+    this.parentId = delegateExecution.getParentId();
+    this.processBusinessKey = delegateExecution.getProcessBusinessKey();
+    this.processDefinitionId = delegateExecution.getProcessDefinitionId();
+    this.processInstanceId = delegateExecution.getProcessInstanceId();
+    this.tenantId = delegateExecution.getTenantId();
+  }
+
+  /**
+   * return the Id of the activity instance currently executed by this execution
+   */
+  public String getActivityInstanceId() {
+    return activityInstanceId;
+  }
+
+  /**
+   * The business key for the root execution (e.g. process instance).
+   */
+  public String getBusinessKey() {
+    return businessKey;
+  }
+
+  /**
+   * Gets the id of the current activity.
+   */
+  public String getCurrentActivityId() {
+    return currentActivityId;
+  }
+
+  /**
+   * Gets the name of the current activity.
+   */
+  public String getCurrentActivityName() {
+    return currentActivityName;
+  }
+
+  /** return the Id of the current transition */
+  public String getCurrentTransitionId() {
+    return currentTransitionId;
+  }
+
+  /**
+   * The {@link ExecutionListener#EVENTNAME_START event name} in case this
+   * execution is passed in for an {@link ExecutionListener}
+   */
+  public String getEventName() {
+    return eventName;
+  }
+
+  /**
+   * Unique id of this path of execution that can be used as a handle to provide
+   * external signals back into the engine after wait states.
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * return the Id of the parent activity instance currently executed by this
+   * execution
+   */
+  public String getParentActivityInstanceId() {
+    return parentActivityInstanceId;
+  }
+
+  /**
+   * Gets the id of the parent of this execution. If null, the execution
+   * represents a process-instance.
+   */
+  public String getParentId() {
+    return parentId;
+  }
+
+  /**
+   * The business key for the process instance this execution is associated
+   * with.
+   */
+  public String getProcessBusinessKey() {
+    return processBusinessKey;
+  }
+
+  /**
+   * The process definition key for the process instance this execution is
+   * associated with.
+   */
+  public String getProcessDefinitionId() {
+    return processDefinitionId;
+  }
+
+  /** Reference to the overall process instance */
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  /**
+   * Return the id of the tenant this execution belongs to. Can be
+   * <code>null</code> if the execution belongs to no single tenant.
+   */
+  public String getTenantId() {
+    return tenantId;
+  }
+
+}

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/TaskEvent.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/TaskEvent.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.event;
+
+import java.util.Date;
+import org.camunda.bpm.engine.delegate.DelegateTask;
+
+public class TaskEvent {
+
+  protected String assignee;
+  protected String caseDefinitionId;
+  protected String caseExecutionId;
+  protected String caseInstanceId;
+  protected Date createTime; // The time when the task has been created
+  protected String deleteReason;
+  protected String description;
+  protected Date dueDate;
+  protected String eventName;
+  protected String executionId;
+  protected Date followUpDate;
+  protected String id;
+  protected String name;
+  protected String owner;
+  protected int priority;
+  protected String processDefinitionId;
+  protected String processInstanceId;
+  protected String taskDefinitionKey;
+  protected String tenantId;
+
+  public TaskEvent(DelegateTask delegateTask) {
+    this.assignee = delegateTask.getAssignee();
+    this.caseDefinitionId = delegateTask.getCaseDefinitionId();
+    this.caseExecutionId = delegateTask.getCaseExecutionId();
+    this.caseInstanceId = delegateTask.getCaseInstanceId();
+    this.createTime = delegateTask.getCreateTime();
+    this.deleteReason = delegateTask.getDeleteReason();
+    this.description = delegateTask.getDescription();
+    this.dueDate = delegateTask.getDueDate();
+    this.eventName = delegateTask.getEventName();
+    this.executionId = delegateTask.getExecutionId();
+    this.followUpDate = delegateTask.getFollowUpDate();
+    this.id = delegateTask.getId();
+    this.name = delegateTask.getName();
+    this.owner = delegateTask.getOwner();
+    this.priority = delegateTask.getPriority();
+    this.processDefinitionId = delegateTask.getProcessDefinitionId();
+    this.processInstanceId = delegateTask.getProcessInstanceId();
+    this.taskDefinitionKey = delegateTask.getTaskDefinitionKey();
+    this.tenantId = delegateTask.getTenantId();
+  }
+
+  /**
+   * The {@link User.getId() userId} of the person to which this task is
+   * delegated.
+   */
+  public String getAssignee() {
+    return assignee;
+  }
+
+  /**
+   * Reference to the case definition or null if it is not related to a case.
+   */
+  public String getCaseDefinitionId() {
+    return caseDefinitionId;
+  }
+
+  /**
+   * Reference to the case execution or null if it is not related to a case
+   * instance.
+   */
+  public String getCaseExecutionId() {
+    return caseExecutionId;
+  }
+
+  /**
+   * Reference to the case instance or null if it is not related to a case
+   * instance.
+   */
+  public String getCaseInstanceId() {
+    return caseInstanceId;
+  }
+
+  /** The date/time when this task was created */
+  public Date getCreateTime() {
+    return createTime;
+  }
+
+  /** Get delete reason of the task. */
+  public String getDeleteReason() {
+    return deleteReason;
+  }
+
+  /** Free text description of the task. */
+  public String getDescription() {
+    return description;
+  }
+
+  /** Due date of the task. */
+  public Date getDueDate() {
+    return dueDate;
+  }
+
+  /**
+   * Returns the event name which triggered the task listener to fire for this
+   * task.
+   */
+  public String getEventName() {
+    return eventName;
+  }
+
+  /**
+   * Reference to the path of execution or null if it is not related to a
+   * process instance.
+   */
+  public String getExecutionId() {
+    return executionId;
+  }
+
+  /** Follow-up date of the task. */
+  public Date getFollowUpDate() {
+    return followUpDate;
+  }
+
+  /** DB id of the task. */
+  public String getId() {
+    return id;
+  }
+
+  /** Name or title of the task. */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * The {@link User.getId() userId} of the person responsible for this task.
+   */
+  public String getOwner() {
+    return owner;
+  }
+
+  /**
+   * indication of how important/urgent this task is with a number between 0 and
+   * 100 where higher values mean a higher priority and lower values mean lower
+   * priority: [0..19] lowest, [20..39] low, [40..59] normal, [60..79] high
+   * [80..100] highest
+   */
+  public int getPriority() {
+    return priority;
+  }
+
+  /**
+   * Reference to the process definition or null if it is not related to a
+   * process.
+   */
+  public String getProcessDefinitionId() {
+    return processDefinitionId;
+  }
+
+  /**
+   * Reference to the process instance or null if it is not related to a process
+   * instance.
+   */
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  /**
+   * The id of the activity in the process defining this task or null if this is
+   * not related to a process
+   */
+  public String getTaskDefinitionKey() {
+    return taskDefinitionKey;
+  }
+
+  /**
+   * Return the id of the tenant this task belongs to. Can be <code>null</code>
+   * if the task belongs to no single tenant.
+   */
+  public String getTenantId() {
+    return tenantId;
+  }
+
+}

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultDeploymentConfigurationTest.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultDeploymentConfigurationTest.java
@@ -53,9 +53,10 @@ public class DefaultDeploymentConfigurationTest {
     defaultDeploymentConfiguration.preInit(configuration);
 
     final Resource[] resources = configuration.getDeploymentResources();
-    assertThat(resources).hasSize(7);
+    assertThat(resources).hasSize(8);
 
-    assertThat(filenames(resources)).containsOnly("async-service-task.bpmn", "test.cmmn10.xml", "test.bpmn", "test.cmmn", "test.bpmn20.xml", "check-order.dmn", "eventing.bpmn");
+    assertThat(filenames(resources)).containsOnly("async-service-task.bpmn", "test.cmmn10.xml", "test.bpmn", "test.cmmn", "test.bpmn20.xml",
+        "check-order.dmn", "eventing.bpmn", "eventingWithTaskAssignee.bpmn");
   }
 
   private Set<String> filenames(Resource[] resources) {

--- a/starter/src/test/resources/bpmn/eventingWithTaskAssignee.bpmn
+++ b/starter/src/test/resources/bpmn/eventingWithTaskAssignee.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1lmgbl7" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="eventingWithAssignment" name="eventing" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0ndk8rv</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0ndk8rv" sourceRef="StartEvent_1" targetRef="user_task" />
+    <bpmn:userTask id="user_task" name="execute&#10;user task" camunda:assignee="testUser">
+      <bpmn:incoming>SequenceFlow_0ndk8rv</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0mjrja8</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0mjrja8" sourceRef="user_task" targetRef="service_task" />
+    <bpmn:serviceTask id="service_task" name="execute service&#10;task" camunda:delegateExpression="${eventingServiceTask}">
+      <bpmn:incoming>SequenceFlow_0mjrja8</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1juyzhf</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_11s18x7">
+      <bpmn:incoming>SequenceFlow_1juyzhf</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1juyzhf" sourceRef="service_task" targetRef="EndEvent_11s18x7" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="eventingWithAssignment">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ndk8rv_di" bpmnElement="SequenceFlow_0ndk8rv">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="242" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_0zqz51t_di" bpmnElement="user_task">
+        <dc:Bounds x="242" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0mjrja8_di" bpmnElement="SequenceFlow_0mjrja8">
+        <di:waypoint x="342" y="121" />
+        <di:waypoint x="392" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_1a8uu7u_di" bpmnElement="service_task">
+        <dc:Bounds x="392" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_11s18x7_di" bpmnElement="EndEvent_11s18x7">
+        <dc:Bounds x="542" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1juyzhf_di" bpmnElement="SequenceFlow_1juyzhf">
+        <di:waypoint x="492" y="121" />
+        <di:waypoint x="542" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
* `TransactionalEventListener`s receive mutable data objects `DelegateTask`
  and `DelegateExecution` whose information might already have been altered
  by the time they are handled in the listener, therefore dispatch an
  immutable data object at the creation time of the event that still
  reflects the data at that point in time later
* publish Task UPDATE events
* only add listeners if properties are enabled, otherwise listeners are always
  added and evaluated (the property is then evaluated in the listener)

related to CAM-10588