### PR TITLE
CAM-10588: dispatch immutable events additionally

### DIFF
--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/ExecutionEvent.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/ExecutionEvent.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.event;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.ExecutionListener;
+
+public class ExecutionEvent {
+
+  protected String activityInstanceId;
+  protected String businessKey;
+  protected String currentActivityId;
+  protected String currentActivityName;
+  protected String currentTransitionId;
+  protected String eventName;
+  protected String id;
+  protected String parentActivityInstanceId;
+  protected String parentId;
+  protected String processBusinessKey;
+  protected String processDefinitionId;
+  protected String processInstanceId;
+  protected String tenantId;
+
+  public ExecutionEvent(DelegateExecution delegateExecution) {
+    this.activityInstanceId = delegateExecution.getActivityInstanceId();
+    this.businessKey = delegateExecution.getBusinessKey();
+    this.currentActivityId = delegateExecution.getCurrentActivityId();
+    this.currentActivityName = delegateExecution.getCurrentActivityName();
+    this.currentTransitionId = delegateExecution.getCurrentTransitionId();
+    this.eventName = delegateExecution.getEventName();
+    this.id = delegateExecution.getId();
+    this.parentActivityInstanceId = delegateExecution.getParentActivityInstanceId();
+    this.parentId = delegateExecution.getParentId();
+    this.processBusinessKey = delegateExecution.getProcessBusinessKey();
+    this.processDefinitionId = delegateExecution.getProcessDefinitionId();
+    this.processInstanceId = delegateExecution.getProcessInstanceId();
+    this.tenantId = delegateExecution.getTenantId();
+  }
+
+  /**
+   * return the Id of the activity instance currently executed by this execution
+   */
+  public String getActivityInstanceId() {
+    return activityInstanceId;
+  }
+
+  /**
+   * The business key for the root execution (e.g. process instance).
+   */
+  public String getBusinessKey() {
+    return businessKey;
+  }
+
+  /**
+   * Gets the id of the current activity.
+   */
+  public String getCurrentActivityId() {
+    return currentActivityId;
+  }
+
+  /**
+   * Gets the name of the current activity.
+   */
+  public String getCurrentActivityName() {
+    return currentActivityName;
+  }
+
+  /** return the Id of the current transition */
+  public String getCurrentTransitionId() {
+    return currentTransitionId;
+  }
+
+  /**
+   * The {@link ExecutionListener#EVENTNAME_START event name} in case this
+   * execution is passed in for an {@link ExecutionListener}
+   */
+  public String getEventName() {
+    return eventName;
+  }
+
+  /**
+   * Unique id of this path of execution that can be used as a handle to provide
+   * external signals back into the engine after wait states.
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * return the Id of the parent activity instance currently executed by this
+   * execution
+   */
+  public String getParentActivityInstanceId() {
+    return parentActivityInstanceId;
+  }
+
+  /**
+   * Gets the id of the parent of this execution. If null, the execution
+   * represents a process-instance.
+   */
+  public String getParentId() {
+    return parentId;
+  }
+
+  /**
+   * The business key for the process instance this execution is associated
+   * with.
+   */
+  public String getProcessBusinessKey() {
+    return processBusinessKey;
+  }
+
+  /**
+   * The process definition key for the process instance this execution is
+   * associated with.
+   */
+  public String getProcessDefinitionId() {
+    return processDefinitionId;
+  }
+
+  /** Reference to the overall process instance */
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  /**
+   * Return the id of the tenant this execution belongs to. Can be
+   * <code>null</code> if the execution belongs to no single tenant.
+   */
+  public String getTenantId() {
+    return tenantId;
+  }
+
+}

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/PublishDelegateParseListener.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/PublishDelegateParseListener.java
@@ -54,17 +54,23 @@ public class PublishDelegateParseListener extends AbstractBpmnParseListener {
 
   public PublishDelegateParseListener(final ApplicationEventPublisher publisher, final EventingProperty property) {
 
-    this.taskListener = delegateTask -> {
-      if (property.isTask()) {
+    if (property.isTask()) {
+      this.taskListener = delegateTask -> {
         publisher.publishEvent(delegateTask);
-      }
-    };
+        publisher.publishEvent(new TaskEvent(delegateTask));
+      };
+    } else {
+      this.taskListener = null;
+    }
 
-    this.executionListener = delegateExecution -> {
-      if (property.isExecution()) {
+    if (property.isExecution()) {
+      this.executionListener = delegateExecution -> {
         publisher.publishEvent(delegateExecution);
-      }
-    };
+        publisher.publishEvent(new ExecutionEvent(delegateExecution));
+      };
+    } else {
+      this.executionListener = null;
+    }
   }
 
 
@@ -177,8 +183,10 @@ public class PublishDelegateParseListener extends AbstractBpmnParseListener {
 
   @Override
   public void parseProcess(Element processElement, ProcessDefinitionEntity processDefinition) {
-    for (String event : EXECUTION_EVENTS) {
-      processDefinition.addListener(event, executionListener);
+    if (executionListener != null) {
+      for (String event : EXECUTION_EVENTS) {
+        processDefinition.addListener(event, executionListener);
+      }
     }
   }
 
@@ -227,20 +235,25 @@ public class PublishDelegateParseListener extends AbstractBpmnParseListener {
     addExecutionListener(activity);
   }
 
-
   private void addExecutionListener(final ActivityImpl activity) {
-    for (String event : EXECUTION_EVENTS) {
-      activity.addListener(event, executionListener);
+    if (executionListener != null) {
+      for (String event : EXECUTION_EVENTS) {
+        activity.addListener(event, executionListener);
+      }
     }
   }
 
   private void addExecutionListener(final TransitionImpl transition) {
-    transition.addListener(EVENTNAME_TAKE, executionListener);
+    if (executionListener != null) {
+      transition.addListener(EVENTNAME_TAKE, executionListener);
+    }
   }
 
   private void addTaskListener(TaskDefinition taskDefinition) {
-    for (String event : TASK_EVENTS) {
-      taskDefinition.addTaskListener(event, taskListener);
+    if (taskListener != null) {
+      for (String event : TASK_EVENTS) {
+        taskDefinition.addTaskListener(event, taskListener);
+      }
     }
   }
 

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/TaskEvent.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/event/TaskEvent.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.event;
+
+import java.util.Date;
+import org.camunda.bpm.engine.delegate.DelegateTask;
+
+public class TaskEvent {
+
+  protected String assignee;
+  protected String caseDefinitionId;
+  protected String caseExecutionId;
+  protected String caseInstanceId;
+  protected Date createTime; // The time when the task has been created
+  protected String deleteReason;
+  protected String description;
+  protected Date dueDate;
+  protected String eventName;
+  protected String executionId;
+  protected String id;
+  protected String name;
+  protected String owner;
+  protected int priority;
+  protected String processDefinitionId;
+  protected String processInstanceId;
+  protected String taskDefinitionKey;
+  protected String tenantId;
+
+  public TaskEvent(DelegateTask delegateTask) {
+    this.assignee = delegateTask.getAssignee();
+    this.caseDefinitionId = delegateTask.getCaseDefinitionId();
+    this.caseExecutionId = delegateTask.getCaseExecutionId();
+    this.caseInstanceId = delegateTask.getCaseInstanceId();
+    this.createTime = delegateTask.getCreateTime();
+    this.deleteReason = delegateTask.getDeleteReason();
+    this.description = delegateTask.getDescription();
+    this.dueDate = delegateTask.getDueDate();
+    this.eventName = delegateTask.getEventName();
+    this.executionId = delegateTask.getExecutionId();
+    this.id = delegateTask.getId();
+    this.name = delegateTask.getName();
+    this.owner = delegateTask.getOwner();
+    this.priority = delegateTask.getPriority();
+    this.processDefinitionId = delegateTask.getProcessDefinitionId();
+    this.processInstanceId = delegateTask.getProcessInstanceId();
+    this.taskDefinitionKey = delegateTask.getTaskDefinitionKey();
+    this.tenantId = delegateTask.getTenantId();
+  }
+
+  /**
+   * The {@link User.getId() userId} of the person to which this task is
+   * delegated.
+   */
+  public String getAssignee() {
+    return assignee;
+  }
+
+  /**
+   * Reference to the case definition or null if it is not related to a case.
+   */
+  public String getCaseDefinitionId() {
+    return caseDefinitionId;
+  }
+
+  /**
+   * Reference to the case execution or null if it is not related to a case
+   * instance.
+   */
+  public String getCaseExecutionId() {
+    return caseExecutionId;
+  }
+
+  /**
+   * Reference to the case instance or null if it is not related to a case
+   * instance.
+   */
+  public String getCaseInstanceId() {
+    return caseInstanceId;
+  }
+
+  /** The date/time when this task was created */
+  public Date getCreateTime() {
+    return createTime;
+  }
+
+  /** Get delete reason of the task. */
+  public String getDeleteReason() {
+    return deleteReason;
+  }
+
+  /** Free text description of the task. */
+  public String getDescription() {
+    return description;
+  }
+
+  /** Due date of the task. */
+  public Date getDueDate() {
+    return dueDate;
+  }
+
+  /**
+   * Returns the event name which triggered the task listener to fire for this
+   * task.
+   */
+  public String getEventName() {
+    return eventName;
+  }
+
+  /**
+   * Reference to the path of execution or null if it is not related to a
+   * process instance.
+   */
+  public String getExecutionId() {
+    return executionId;
+  }
+
+  /** DB id of the task. */
+  public String getId() {
+    return id;
+  }
+
+  /** Name or title of the task. */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * The {@link User.getId() userId} of the person responsible for this task.
+   */
+  public String getOwner() {
+    return owner;
+  }
+
+  /**
+   * indication of how important/urgent this task is with a number between 0 and
+   * 100 where higher values mean a higher priority and lower values mean lower
+   * priority: [0..19] lowest, [20..39] low, [40..59] normal, [60..79] high
+   * [80..100] highest
+   */
+  public int getPriority() {
+    return priority;
+  }
+
+  /**
+   * Reference to the process definition or null if it is not related to a
+   * process.
+   */
+  public String getProcessDefinitionId() {
+    return processDefinitionId;
+  }
+
+  /**
+   * Reference to the process instance or null if it is not related to a process
+   * instance.
+   */
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  /**
+   * The id of the activity in the process defining this task or null if this is
+   * not related to a process
+   */
+  public String getTaskDefinitionKey() {
+    return taskDefinitionKey;
+  }
+
+  /**
+   * Return the id of the tenant this task belongs to. Can be <code>null</code>
+   * if the task belongs to no single tenant.
+   */
+  public String getTenantId() {
+    return tenantId;
+  }
+
+}

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CamundaEventingIT.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CamundaEventingIT.java
@@ -19,12 +19,13 @@ package org.camunda.bpm.spring.boot.starter;
 import org.assertj.core.util.DateUtil;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.delegate.TaskListener;
 import org.camunda.bpm.engine.impl.history.event.HistoricIdentityLinkLogEventEntity;
 import org.camunda.bpm.engine.impl.history.event.HistoricTaskInstanceEventEntity;
 import org.camunda.bpm.engine.impl.history.event.HistoryEvent;
-import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.spring.boot.starter.event.TaskEvent;
 import org.camunda.bpm.spring.boot.starter.test.nonpa.TestApplication;
 import org.camunda.bpm.spring.boot.starter.test.nonpa.TestEventCaptor;
 import org.junit.After;
@@ -37,7 +38,6 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import javax.transaction.Transactional;
 import java.util.Date;
 
 import static junit.framework.TestCase.fail;
@@ -49,7 +49,6 @@ import static org.assertj.core.api.Assertions.assertThat;
   webEnvironment = WebEnvironment.NONE
 )
 @ActiveProfiles("eventing")
-@Transactional
 public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
 
   @Autowired
@@ -65,13 +64,7 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
 
   @Before
   public void init() {
-    ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery()
-      .processDefinitionKey("eventing")
-      .singleResult();
-    assertThat(processDefinition).isNotNull();
-
-    eventCaptor.historyEvents.clear();
-    instance = runtime.startProcessInstanceByKey("eventing");
+    eventCaptor.clear();
   }
 
   @After
@@ -87,98 +80,95 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
 
   @Test
   public final void shouldEventTaskCreation() {
+    // when
+    startEventingInstance();
 
-    assertThat(eventCaptor.taskEvents).isNotEmpty();
-
+    // then
     Task task = taskService.createTaskQuery().active().singleResult();
-    TestEventCaptor.TaskEvent taskEvent = eventCaptor.taskEvents.pop();
+    assertTaskEvents(task, TaskListener.EVENTNAME_CREATE);
+  }
 
-    assertThat(taskEvent.eventName).isEqualTo("create");
-    assertThat(taskEvent.id).isEqualTo(task.getId());
-    assertThat(taskEvent.processInstanceId).isEqualTo(task.getProcessInstanceId());
+  @Test
+  public final void shouldEventTaskCreationWithAssignment() {
+    // when
+    instance = runtime.startProcessInstanceByKey("eventingWithAssignment");
+
+    // then
+    Task task = taskService.createTaskQuery().active().singleResult();
+    // two events fired ('create' and then 'assignment')
+    assertTaskEvents(task, 2, TaskListener.EVENTNAME_CREATE, TaskListener.EVENTNAME_ASSIGNMENT);
   }
 
   @Test
   public final void shouldEventTaskAssignment() {
-
     // given
-    assertThat(eventCaptor.taskEvents).isNotEmpty();
-    eventCaptor.taskEvents.clear();
+    startEventingInstance();
     Task task = taskService.createTaskQuery().active().singleResult();
+    eventCaptor.clear();
 
     // when
     taskService.setAssignee(task.getId(), "kermit");
 
     // then
-    TestEventCaptor.TaskEvent taskEvent = eventCaptor.taskEvents.pop();
-    assertThat(taskEvent.eventName).isEqualTo("assignment");
-    assertThat(taskEvent.id).isEqualTo(task.getId());
-    assertThat(taskEvent.processInstanceId).isEqualTo(task.getProcessInstanceId());
+    assertTaskEvents(task, TaskListener.EVENTNAME_ASSIGNMENT);
   }
-
 
   @Test
   public final void shouldEventTaskComplete() {
-
     // given
-    assertThat(eventCaptor.taskEvents).isNotEmpty();
-    eventCaptor.taskEvents.clear();
+    startEventingInstance();
     Task task = taskService.createTaskQuery().active().singleResult();
+    eventCaptor.clear();
 
     // when
     taskService.complete(task.getId());
 
     // then
-    TestEventCaptor.TaskEvent taskEvent = eventCaptor.taskEvents.pop();
-    assertThat(taskEvent.eventName).isEqualTo("complete");
-    assertThat(taskEvent.id).isEqualTo(task.getId());
-    assertThat(taskEvent.processInstanceId).isEqualTo(task.getProcessInstanceId());
+    assertTaskEvents(task, TaskListener.EVENTNAME_COMPLETE);
   }
 
   @Test
   public final void shouldEventTaskDelete() {
-
     // given
-    assertThat(eventCaptor.taskEvents).isNotEmpty();
-    eventCaptor.taskEvents.clear();
+    startEventingInstance();
     Task task = taskService.createTaskQuery().active().singleResult();
+    eventCaptor.clear();
 
     // when
     runtimeService.deleteProcessInstance(instance.getProcessInstanceId(), "no need");
 
     // then
-    TestEventCaptor.TaskEvent taskEvent = eventCaptor.taskEvents.pop();
-    assertThat(taskEvent.eventName).isEqualTo("delete");
-    assertThat(taskEvent.id).isEqualTo(task.getId());
-    assertThat(taskEvent.processInstanceId).isEqualTo(task.getProcessInstanceId());
+    assertTaskEvents(task, TaskListener.EVENTNAME_DELETE);
   }
 
   @Test
   public final void shouldEventExecution() {
     // given
-    assertThat(eventCaptor.executionEvents).isNotEmpty();
-    eventCaptor.executionEvents.clear();
+    startEventingInstance();
     Task task = taskService.createTaskQuery().active().singleResult();
+    eventCaptor.clear();
 
     // when
     taskService.complete(task.getId());
 
-    // then 7
+    // then 8
     // 2 for user task (take, end)
     // 3 for service task (start, take, end)
     // 2 for end event (start, end)
     // 1 for process (end)
-    assertThat(eventCaptor.executionEvents.size()).isEqualTo(2 + 3 + 2 + 1);
+    int expectedCount = 2 + 3 + 2 + 1;
+    assertThat(eventCaptor.executionEvents).hasSize(expectedCount);
+    assertThat(eventCaptor.immutableExecutionEvents).hasSize(expectedCount);
+    assertThat(eventCaptor.transactionExecutionEvents).hasSize(expectedCount);
+    assertThat(eventCaptor.transactionImmutableExecutionEvents).hasSize(expectedCount);
   }
 
   @Test
   public final void shouldEventHistoryTaskAssignmentChanges() {
     // given
-    assertThat(eventCaptor.historyEvents).isNotEmpty();
-    eventCaptor.historyEvents.clear();
-    assertThat(eventCaptor.historyEvents).isEmpty();
-
+    startEventingInstance();
     Task task = taskService.createTaskQuery().active().singleResult();
+    eventCaptor.clear();
 
     // when
     taskService.addCandidateUser(task.getId(), "userId");
@@ -236,18 +226,18 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
     assertThat(eventCaptor.historyEvents).isEmpty();
   }
 
-
   @Test
   public void shouldEventHistoryTaskAttributeChanges() {
-    assertThat(eventCaptor.historyEvents).isNotEmpty();
-    eventCaptor.historyEvents.clear();
-
+    // given
+    startEventingInstance();
     Task task = taskService.createTaskQuery().active().singleResult();
+    eventCaptor.clear();
 
+    // when
     task.setName("new Name");
     taskService.saveTask(task);
 
-
+    // then
     HistoryEvent taskChangeEvent = eventCaptor.historyEvents.pop();
     assertThat(taskChangeEvent.getEventType()).isEqualTo("update");
     if (taskChangeEvent instanceof HistoricTaskInstanceEventEntity) {
@@ -260,13 +250,10 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
 
   @Test
   public void shouldEventHistoryTaskMultipleAssignmentChanges() {
-
     // given
-    assertThat(eventCaptor.historyEvents).isNotEmpty();
-    eventCaptor.historyEvents.clear();
-    assertThat(eventCaptor.historyEvents).isEmpty();
-
+    startEventingInstance();
     Task task = taskService.createTaskQuery().active().singleResult();
+    eventCaptor.clear();
 
     // when
     taskService.addCandidateUser(task.getId(), "user1");
@@ -301,16 +288,18 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
 
   @Test
   public void shouldEventHistoryTaskFollowUpDateChanges() {
-    assertThat(eventCaptor.historyEvents).isNotEmpty();
-    eventCaptor.historyEvents.clear();
-
+    // given
+    startEventingInstance();
     Task task = taskService.createTaskQuery().active().singleResult();
+    eventCaptor.clear();
 
     Date now = DateUtil.now();
 
+    // when
     task.setFollowUpDate(now);
     taskService.saveTask(task);
 
+    // then
     HistoryEvent taskChangeEvent = eventCaptor.historyEvents.pop();
     assertThat(taskChangeEvent.getEventType()).isEqualTo("update");
     if (taskChangeEvent instanceof HistoricTaskInstanceEventEntity) {
@@ -318,5 +307,38 @@ public class CamundaEventingIT extends AbstractCamundaAutoConfigurationIT {
     } else {
       fail("Expected task instance change event");
     }
+  }
+
+  protected void assertTaskEvents(Task task, String event) {
+    assertTaskEvents(task, 1, event);
+  }
+
+  protected void assertTaskEvents(Task task, int numberOfEvents, String...events) {
+    assertThat(eventCaptor.taskEvents).hasSize(numberOfEvents);
+    assertThat(eventCaptor.immutableTaskEvents).hasSize(numberOfEvents);
+    assertThat(eventCaptor.transactionTaskEvents).hasSize(numberOfEvents);
+    assertThat(eventCaptor.transactionImmutableTaskEvents).hasSize(numberOfEvents);
+
+    for (int i = 0; i < numberOfEvents; i++) {
+      /*
+       * oldest event happened before latest does not work for mutable transaction
+       * listener events since the delegate task was altered to assignment when the
+       * event is dispatched to the listener
+       */
+      assertTaskEvent(task, eventCaptor.taskEvents.pop(), events[i]);
+      assertTaskEvent(task, eventCaptor.immutableTaskEvents.pop(), events[i]);
+      assertTaskEvent(task, eventCaptor.transactionTaskEvents.pop(), events[0]);
+      assertTaskEvent(task, eventCaptor.transactionImmutableTaskEvents.pop(), events[i]);
+    }
+  }
+
+  protected void assertTaskEvent(Task task, TaskEvent taskEvent, String event) {
+    assertThat(taskEvent.getEventName()).isEqualTo(event);
+    assertThat(taskEvent.getId()).isEqualTo(task.getId());
+    assertThat(taskEvent.getProcessInstanceId()).isEqualTo(task.getProcessInstanceId());
+  }
+
+  protected void startEventingInstance() {
+    instance = runtime.startProcessInstanceByKey("eventing");
   }
 }

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultDeploymentConfigurationTest.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/configuration/impl/DefaultDeploymentConfigurationTest.java
@@ -53,9 +53,10 @@ public class DefaultDeploymentConfigurationTest {
     defaultDeploymentConfiguration.preInit(configuration);
 
     final Resource[] resources = configuration.getDeploymentResources();
-    assertThat(resources).hasSize(7);
+    assertThat(resources).hasSize(8);
 
-    assertThat(filenames(resources)).containsOnly("async-service-task.bpmn", "test.cmmn10.xml", "test.bpmn", "test.cmmn", "test.bpmn20.xml", "check-order.dmn", "eventing.bpmn");
+    assertThat(filenames(resources)).containsOnly("async-service-task.bpmn", "test.cmmn10.xml", "test.bpmn", "test.cmmn", "test.bpmn20.xml",
+        "check-order.dmn", "eventing.bpmn", "eventingWithTaskAssignee.bpmn");
   }
 
   private Set<String> filenames(Resource[] resources) {

--- a/starter/src/test/resources/bpmn/eventingWithTaskAssignee.bpmn
+++ b/starter/src/test/resources/bpmn/eventingWithTaskAssignee.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1lmgbl7" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="eventingWithAssignment" name="eventing" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0ndk8rv</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0ndk8rv" sourceRef="StartEvent_1" targetRef="user_task" />
+    <bpmn:userTask id="user_task" name="execute&#10;user task" camunda:assignee="testUser">
+      <bpmn:incoming>SequenceFlow_0ndk8rv</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0mjrja8</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0mjrja8" sourceRef="user_task" targetRef="service_task" />
+    <bpmn:serviceTask id="service_task" name="execute service&#10;task" camunda:delegateExpression="${eventingServiceTask}">
+      <bpmn:incoming>SequenceFlow_0mjrja8</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1juyzhf</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_11s18x7">
+      <bpmn:incoming>SequenceFlow_1juyzhf</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1juyzhf" sourceRef="service_task" targetRef="EndEvent_11s18x7" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="eventingWithAssignment">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ndk8rv_di" bpmnElement="SequenceFlow_0ndk8rv">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="242" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_0zqz51t_di" bpmnElement="user_task">
+        <dc:Bounds x="242" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0mjrja8_di" bpmnElement="SequenceFlow_0mjrja8">
+        <di:waypoint x="342" y="121" />
+        <di:waypoint x="392" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_1a8uu7u_di" bpmnElement="service_task">
+        <dc:Bounds x="392" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_11s18x7_di" bpmnElement="EndEvent_11s18x7">
+        <dc:Bounds x="542" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1juyzhf_di" bpmnElement="SequenceFlow_1juyzhf">
+        <di:waypoint x="492" y="121" />
+        <di:waypoint x="542" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
* `TransactionalEventListener`s receive mutable data objects `DelegateTask`
  and `DelegateExecution` whose information might already have been altered
  by the time they are handled in the listener, therefore dispatch an
  immutable data object at the creation time of the event that still
  reflects the data at that point in time later
* only add listeners if properties are enabled, otherwise listeners are always
  added and evaluated (the property is then evaluated in the listener)

related to CAM-10588