### PR TITLE
CAM-10187: enable custom context path

### DIFF
--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/SpringBootProcessApplication.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/SpringBootProcessApplication.java
@@ -41,7 +41,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.ServletContextAware;
@@ -89,7 +88,7 @@ public class SpringBootProcessApplication extends SpringProcessApplication {
       .ifPresent(this::setBeanName);
 
     if (camundaBpmProperties.getGenerateUniqueProcessApplicationName()) {
-      setBeanName(CamundaBpmProperties.getUniqueName(camundaBpmProperties.UNIQUE_APPLICATION_NAME_PREFIX));
+      setBeanName(CamundaBpmProperties.getUniqueName(CamundaBpmProperties.UNIQUE_APPLICATION_NAME_PREFIX));
     }
 
     String processEngineName = processEngine.getName();
@@ -118,8 +117,12 @@ public class SpringBootProcessApplication extends SpringProcessApplication {
   }
 
   @ConditionalOnWebApplication
-  @Configuration
-  class WebApplicationConfiguration implements ServletContextAware {
+  @Bean
+  public WebApplicationConfiguration myWebAppConfiguration() {
+    return new WebApplicationConfiguration();
+  }
+
+  public class WebApplicationConfiguration implements ServletContextAware {
 
     @Override
     public void setServletContext(ServletContext servletContext) {

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CustomContextPathProcessApplicationIT.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CustomContextPathProcessApplicationIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.camunda.bpm.application.ProcessApplicationInfo;
+import org.camunda.bpm.engine.spring.application.SpringProcessApplication;
+import org.camunda.bpm.spring.boot.starter.test.pa.TestProcessApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+  classes = { TestProcessApplication.class },
+  webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ActiveProfiles("customContextPath")
+public class CustomContextPathProcessApplicationIT {
+
+  @Autowired
+  private SpringProcessApplication application;
+
+  @Test
+  public void testPostDeployEvent() {
+    assertNotNull(application);
+    assertEquals("/", application.getProperties().get(ProcessApplicationInfo.PROP_SERVLET_CONTEXT_PATH));
+  }
+
+}

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CustomContextPathWebProcessApplicationIT.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CustomContextPathWebProcessApplicationIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.camunda.bpm.application.ProcessApplicationInfo;
+import org.camunda.bpm.engine.spring.application.SpringProcessApplication;
+import org.camunda.bpm.spring.boot.starter.test.pa.TestProcessApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+  classes = { TestProcessApplication.class },
+  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ActiveProfiles("customContextPath")
+public class CustomContextPathWebProcessApplicationIT {
+
+  @Autowired
+  private SpringProcessApplication application;
+
+  @Test
+  public void testPostDeployEvent() {
+    assertNotNull(application);
+    assertEquals("/my/custom/context/path", application.getProperties().get(ProcessApplicationInfo.PROP_SERVLET_CONTEXT_PATH));
+  }
+
+}

--- a/starter/src/test/resources/application-customContextPath.properties
+++ b/starter/src/test/resources/application-customContextPath.properties
@@ -1,0 +1,1 @@
+server.servlet.contextPath=/my/custom/context/path


### PR DESCRIPTION
* `ServletContextAware` classes with `@Configuration` annotation are not invoked
  by Spring Boot anymore
* work around this limitation by creating a bean in the application that is
  `ServletContextAware` and adjusts the `contextPath` of the application in
  case of a web application

related to CAM-10187