### PR TITLE
CAM-10613: replace rest-core with jaxrs 2 artifact

### DIFF
--- a/starter-webapp-core/pom.xml
+++ b/starter-webapp-core/pom.xml
@@ -26,6 +26,17 @@
       <artifactId>camunda-webapp</artifactId>
       <type>jar</type>
       <classifier>classes</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.camunda.bpm</groupId>
+          <artifactId>camunda-engine-rest-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.bpm</groupId>
+      <artifactId>camunda-engine-rest-jaxrs2</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
* pull more functionality than necessary into the starter-webapp
  in order to allow arbitrary ordering of artifacts in applications
  using the starter-rest as well, otherwise the fetch and lock
  implementation of the rest-core will be used if the starter-webapp
  is defined first in the application's POM

related to [CAM-10613](https://app.camunda.com/jira/browse/CAM-10613)