### PR TITLE
[CAM-10902] use springBoot version 2.2.1.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </modules>
 
   <properties>
-    <spring-boot.version>2.1.8.RELEASE</spring-boot.version>
+    <spring-boot.version>2.2.1.RELEASE</spring-boot.version>
     <!-- for SNAPSHOT versions ${camunda.version} and ${camunda-webapp-ee.version} will be the same, for released versions, the latter must be with -ee suffix -->
     <camunda.version>7.12.0-SNAPSHOT</camunda.version>
     <!-- for SNAPSHOT versions the camunda.version stays as it is, e.g. 7.12.0-SNAPSHOT -->


### PR DESCRIPTION
[![CAM-10902](https://badgen.net/badge/JIRA/CAM-10902/0052CC)](https://app.camunda.com/jira/browse/CAM-10902)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Just setting the version to latest release (following the idea, that when a camunda starter is released, it should support the latest spring boot version) ... see https://app.camunda.com/jira/browse/CAM-10902

This might require more work to be done ... let's see how the checks turn out