### PR TITLE
[CAM-10187] fix(starter): revert enable custom context path

### DIFF
--- a/starter-qa/integration-test-simple/pom.xml
+++ b/starter-qa/integration-test-simple/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.camunda.bpm.springboot.project</groupId>
+    <artifactId>camunda-bpm-spring-boot-starter-qa</artifactId>
+    <version>3.4.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>qa-simple</artifactId>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.camunda.bpm.springboot</groupId>
+      <artifactId>camunda-bpm-spring-boot-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.bpm.springboot</groupId>
+      <artifactId>camunda-bpm-spring-boot-starter-test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <id>pre-integration-test</id>
+            <goals>
+              <goal>start</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>post-integration-test</id>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/starter-qa/integration-test-simple/src/test/java/org/camunda/bpm/springboot/project/qa/simple/Application.java
+++ b/starter-qa/integration-test-simple/src/test/java/org/camunda/bpm/springboot/project/qa/simple/Application.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.springboot.project.qa.simple;
+
+import org.camunda.bpm.spring.boot.starter.annotation.EnableProcessApplication;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+@EnableProcessApplication("myProcessApplication")
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+
+}

--- a/starter-qa/integration-test-simple/src/test/java/org/camunda/bpm/springboot/project/qa/simple/SimpleApplicationIT.java
+++ b/starter-qa/integration-test-simple/src/test/java/org/camunda/bpm/springboot/project/qa/simple/SimpleApplicationIT.java
@@ -14,40 +14,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.camunda.bpm.spring.boot.starter;
+package org.camunda.bpm.springboot.project.qa.simple;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.camunda.bpm.application.ProcessApplicationInfo;
-import org.camunda.bpm.engine.spring.application.SpringProcessApplication;
-import org.camunda.bpm.spring.boot.starter.test.pa.TestProcessApplication;
-import org.junit.Ignore;
+import org.camunda.bpm.engine.RuntimeService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(
-  classes = { TestProcessApplication.class },
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
-)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@ActiveProfiles("customContextPath")
-public class CustomContextPathWebProcessApplicationIT {
+@SpringBootTest(classes = { Application.class },
+                webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class SimpleApplicationIT {
 
   @Autowired
-  private SpringProcessApplication application;
+  RuntimeService runtimeService;
 
-  @Ignore("CAM-10187")
   @Test
-  public void testPostDeployEvent() {
-    assertNotNull(application);
-    assertEquals("/my/custom/context/path", application.getProperties().get(ProcessApplicationInfo.PROP_SERVLET_CONTEXT_PATH));
+  public void shouldStartApplicationSuccessfully() {
+    // then no exception due to missing classes is thrown
+    assertThat(runtimeService).isNotNull();
   }
 
 }

--- a/starter-qa/integration-test-simple/src/test/resources/logback-test.xml
+++ b/starter-qa/integration-test-simple/src/test/resources/logback-test.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/base.xml"/>
+  <logger name="org.springframework" level="info"/>
+  <logger name="org.hibernate" level="info"/>
+  <logger name="org.camunda" level="info"/>
+  <logger name="org.camunda.bpm.engine.persistence" level="warn"/>
+</configuration>

--- a/starter-qa/pom.xml
+++ b/starter-qa/pom.xml
@@ -17,6 +17,7 @@
   <artifactId>camunda-bpm-spring-boot-starter-qa</artifactId>
 
   <modules>
+    <module>integration-test-simple</module>
     <module>integration-test-webapp</module>
     <module>integration-test-plugins</module>
   </modules>

--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/SpringBootProcessApplication.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/SpringBootProcessApplication.java
@@ -41,6 +41,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.ServletContextAware;
@@ -88,7 +89,7 @@ public class SpringBootProcessApplication extends SpringProcessApplication {
       .ifPresent(this::setBeanName);
 
     if (camundaBpmProperties.getGenerateUniqueProcessApplicationName()) {
-      setBeanName(CamundaBpmProperties.getUniqueName(CamundaBpmProperties.UNIQUE_APPLICATION_NAME_PREFIX));
+      setBeanName(CamundaBpmProperties.getUniqueName(camundaBpmProperties.UNIQUE_APPLICATION_NAME_PREFIX));
     }
 
     String processEngineName = processEngine.getName();
@@ -117,12 +118,8 @@ public class SpringBootProcessApplication extends SpringProcessApplication {
   }
 
   @ConditionalOnWebApplication
-  @Bean
-  public WebApplicationConfiguration myWebAppConfiguration() {
-    return new WebApplicationConfiguration();
-  }
-
-  public class WebApplicationConfiguration implements ServletContextAware {
+  @Configuration
+  class WebApplicationConfiguration implements ServletContextAware {
 
     @Override
     public void setServletContext(ServletContext servletContext) {


### PR DESCRIPTION
[![CAM-10187](https://badgen.net/badge/JIRA/CAM-10187/0052CC)](https://app.camunda.com/jira/browse/CAM-10187)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* commit 14564c671744935fc8c442077578041f2186f595
  introduced a dependency on starter-web for all users of the starter
  because `ServletContextAware` is bound at compile time of
  `SpringBootProcessApplication`
* reverting the behavior, so custom context paths are still not possible
* introducing a simple IT test without web dependencies to make sure a
  new fix does not break this

related to CAM-10187