### PR TITLE
[CAM-10187] fix(starter): enable custom context path

### DIFF
--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/SpringBootProcessApplication.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/SpringBootProcessApplication.java
@@ -41,10 +41,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.ServletContextAware;
 
+@Configuration
 public class SpringBootProcessApplication extends SpringProcessApplication {
 
   @Bean
@@ -117,12 +119,8 @@ public class SpringBootProcessApplication extends SpringProcessApplication {
   }
 
   @ConditionalOnWebApplication
-  @Bean
-  public WebApplicationConfiguration myWebAppConfiguration() {
-    return new WebApplicationConfiguration();
-  }
-
-  public class WebApplicationConfiguration implements ServletContextAware {
+  @Configuration
+  class WebApplicationConfiguration implements ServletContextAware {
 
     @Override
     public void setServletContext(ServletContext servletContext) {


### PR DESCRIPTION
[![CAM-10187](https://badgen.net/badge/JIRA/CAM-10187/0052CC)](https://app.camunda.com/jira/browse/CAM-10187)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* add `@Configuration` annotation to `SpringBootProcessApplication`
  because nested `@Configuration` classes are only scanned for
  classes that are annotated with `@Component` since Spring 5.1.x

related to CAM-10187