### PR TITLE
[CAM-10187] fix(starter): enable custom context path

### DIFF
--- a/starter/src/main/java/org/camunda/bpm/spring/boot/starter/SpringBootProcessApplication.java
+++ b/starter/src/main/java/org/camunda/bpm/spring/boot/starter/SpringBootProcessApplication.java
@@ -46,6 +46,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.ServletContextAware;
 
+@Configuration
 public class SpringBootProcessApplication extends SpringProcessApplication {
 
   @Bean
@@ -89,7 +90,7 @@ public class SpringBootProcessApplication extends SpringProcessApplication {
       .ifPresent(this::setBeanName);
 
     if (camundaBpmProperties.getGenerateUniqueProcessApplicationName()) {
-      setBeanName(CamundaBpmProperties.getUniqueName(camundaBpmProperties.UNIQUE_APPLICATION_NAME_PREFIX));
+      setBeanName(CamundaBpmProperties.getUniqueName(CamundaBpmProperties.UNIQUE_APPLICATION_NAME_PREFIX));
     }
 
     String processEngineName = processEngine.getName();

--- a/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CustomContextPathWebProcessApplicationIT.java
+++ b/starter/src/test/java/org/camunda/bpm/spring/boot/starter/CustomContextPathWebProcessApplicationIT.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNotNull;
 import org.camunda.bpm.application.ProcessApplicationInfo;
 import org.camunda.bpm.engine.spring.application.SpringProcessApplication;
 import org.camunda.bpm.spring.boot.starter.test.pa.TestProcessApplication;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,7 +42,6 @@ public class CustomContextPathWebProcessApplicationIT {
   @Autowired
   private SpringProcessApplication application;
 
-  @Ignore("CAM-10187")
   @Test
   public void testPostDeployEvent() {
     assertNotNull(application);


### PR DESCRIPTION
[![CAM-10187](https://badgen.net/badge/JIRA/CAM-10187/0052CC)](https://app.camunda.com/jira/browse/CAM-10187)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* add `@Configuration` annotation to `SpringBootProcessApplication`
  because nested `@Configuration` classes are only scanned for
  classes that are annotated with `@Component` since Spring 5.1.x

related to CAM-10187