### PR TITLE
add .mvn/maven.config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ target/
 pom.xml.versionsBackup
 github-pages/
 /.gradle/
+.mvn/maven.config


### PR DESCRIPTION
[![](https://badgen.net/badge/JIRA//0052CC)](https://app.camunda.com/jira/browse/)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is a little change that allows external developers like me to define local maven.conig settings, for example adding additional repositories and credentials to work with the ee-modules.

It prevents accidentally checking in those additional maven config with other commits.