### PR TITLE
chore: switch to non deprecated URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,12 +205,12 @@
     <repository>
       <id>camunda-nexus</id>
       <name>camunda bpm</name>
-      <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm</url>
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm/</url>
     </repository>
     <snapshotRepository>
       <id>camunda-nexus</id>
       <name>camunda bpm snapshots</name>
-      <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-snapshots</url>
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-snapshots/</url>
       <uniqueVersion>true</uniqueVersion>
     </snapshotRepository>
   </distributionManagement>
@@ -219,7 +219,7 @@
     <repository>
       <id>camunda.com.public</id>
       <name>Camunda Repository</name>
-      <url>https://app.camunda.com/nexus/content/groups/public</url>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
related to a change that was announced a while ago https://camunda.com/blog/2022/03/a-new-domain-name-for-camunda-artifactory/